### PR TITLE
Fix ContractManager bug to ensure variable reversion upon exception

### DIFF
--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -216,7 +216,6 @@ class ContractManager : BaseContract {
      * Adds contract create and validate functions to the respective maps
      * @tparam Contract Contract type
      * @param createFunc Function to create a new contract
-     * @param validateFunc Function to validate a new contract
      */
     template <typename Contract>
     void addContractFuncs(std::function<void(const ethCallInfo &)> createFunc) {

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -463,7 +463,8 @@ class ContractManagerInterface {
     * @tparam Args The arguments types.
     * @param fromAddr The address of the caller.
     * @param targetAddr The address of the contract to call.
-    * @param value Flag to indicate if the function is payable.
+    * @param value Flag to indicate if the function is payable.,
+    * @param commit Flag to set contract->commit same as caller.
     * @param func The function to call.
     * @param args The arguments to pass to the function.
     * @return The return value of the function.
@@ -508,6 +509,7 @@ class ContractManagerInterface {
     * @param fromAddr The address of the caller.
     * @param targetAddr The address of the contract to call.
     * @param value Flag to indicate if the function is payable.
+    * @param commit Flag to set contract->commit same as caller.
     * @param func The function to call.
     * @return The return value of the function.
     */

--- a/src/contract/dynamiccontract.h
+++ b/src/contract/dynamiccontract.h
@@ -629,7 +629,6 @@ class DynamicContract : public BaseContract {
     * Call the create function of a contract.
     * @tparam TContract The contract type.
     * @tparam Args The arguments of the contract constructor.
-    * @param from The address of the sender.
     * @param gas The gas limit.
     * @param gasPrice The gas price.
     * @param value The caller value.

--- a/src/contract/erc20.cpp
+++ b/src/contract/erc20.cpp
@@ -19,7 +19,6 @@ ERC20::ERC20(ContractManagerInterface &interface, const Address& address, const 
     this->_allowed[Address(dbEntry.key)][Address(valueView.subspan(0, 20))] = Utils::fromBigEndian<uint256_t>(valueView.subspan(20));
   }
   this->registerContractFunctions();
-  updateState(true);
 }
 
 ERC20::ERC20(
@@ -36,7 +35,6 @@ ERC20::ERC20(
   _decimals = erc20_decimals;
   _mintValue(creator, mintValue);
   this->registerContractFunctions();
-  updateState(true);
 }
 
 ERC20::~ERC20() {

--- a/src/contract/erc20wrapper.cpp
+++ b/src/contract/erc20wrapper.cpp
@@ -10,7 +10,6 @@ ERC20Wrapper::ERC20Wrapper(
     BytesArrView valueView(dbEntry.value);
     this->_tokensAndBalances[Address(dbEntry.key)][Address(valueView.subspan(0, 20))] = Utils::fromBigEndian<uint256_t>(valueView.subspan(20));
   }
-  updateState(true);
 }
 
 ERC20Wrapper::ERC20Wrapper(
@@ -20,7 +19,6 @@ ERC20Wrapper::ERC20Wrapper(
   _tokensAndBalances(this)
 {
   registerContractFunctions();
-  updateState(true);
 }
 
 ERC20Wrapper::~ERC20Wrapper() {

--- a/src/contract/nativewrapper.cpp
+++ b/src/contract/nativewrapper.cpp
@@ -19,7 +19,6 @@ NativeWrapper::NativeWrapper(ContractManagerInterface &interface, const Address&
     this->_allowed[Address(dbEntry.key)][Address(keyView.subspan(0, 20))] = Utils::fromBigEndian<uint256_t>(keyView.subspan(20));
   }
   this->registerContractFunctions();
-  updateState(true);
 }
 
 NativeWrapper::NativeWrapper(
@@ -35,7 +34,6 @@ NativeWrapper::NativeWrapper(
   _symbol = erc20_symbol;
   _decimals = erc20_decimals;
   this->registerContractFunctions();
-  updateState(true);
 }
 
 NativeWrapper::~NativeWrapper() {

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -213,11 +213,8 @@ namespace TERC20 {
           randomPrivKey
         );
 
-        std::cout << "REQUIRE THROW" << std::endl;
         REQUIRE_THROWS(contractManager->validateCallContractWithTx(transferTxThrows.txToCallInfo()));
-        std::cout << "DONT THROW" << std::endl;
         contractManager->validateCallContractWithTx(transferTx.txToCallInfo());
-        std::cout << "THROWED" << std::endl;
 
         Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceMeEncoder.getFunctor(), getBalanceMeEncoder.getData()));
         ABI::Decoder getBalanceMeDecoder({ABI::Types::uint256}, getBalanceMeResult);

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -213,8 +213,11 @@ namespace TERC20 {
           randomPrivKey
         );
 
+        std::cout << "REQUIRE THROW" << std::endl;
         REQUIRE_THROWS(contractManager->validateCallContractWithTx(transferTxThrows.txToCallInfo()));
+        std::cout << "DONT THROW" << std::endl;
         contractManager->validateCallContractWithTx(transferTx.txToCallInfo());
+        std::cout << "THROWED" << std::endl;
 
         Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceMeEncoder.getFunctor(), getBalanceMeEncoder.getData()));
         ABI::Decoder getBalanceMeDecoder({ABI::Types::uint256}, getBalanceMeResult);


### PR DESCRIPTION
This PR addresses a critical bug within the ContractManager, which currently allows variables to remain unreverted when an exception is thrown.

The bug manifests when variables are registered and subsequently reverted within their respective contracts. For instance, if a call to function A::A() triggers calls to B::B() and C::C(), and an exception is thrown after calling C::C() but before the A::A() call returns, the variables within B and C will not be reverted. This is because their scopes have already exited, and these variables are not registered within A's scope. This scenario can lead to severe exploits, particularly when a contract call triggers another contract call, and then an exception is thrown, causing the variables within the called contracts to remain unreverted.

To remedy this, the responsibility for registering the variables has been shifted from the individual contracts to the ContractManager. The ContractManager now handles the reversion process after each callContract(...) operation, rather than leaving it to the individual contracts.

The updated variable registration process is as follows:

When a SafeBase variable is used, it triggers the markAsUsed() function, which calls registerVariableUse. This sets off a chain of calls - DynamicContract::registerVariableUse, followed by ContractManagerInterface::registerVariableUse(). The latter appends the variable to a vector of SafeBase references for used variables within the respective contract call.

```mermaid
---
title: "SafeBase registration"
---
flowchart
	297526["\nthis->markAsUsed()"] --> 981210["registerVariableUse()"]
	388929["\nnon-const SafeBase function/operator"] --> 297526
	981210 --> 210746["\nDynamicContract::registerVariableUse()"]
	210746 --> 130403["ContractManagerInterface::registerVariableUse()"]

%% Mermaid Flow Diagram Link
%% Keep this link to make future edits to your diagram
%% https://www.mermaidflow.app/flowchart#N4IgZgNg9g7iBcoB2UAmBTAzgg2qGAlqgC4AWCAzAIwUA0Ip6BA5qcQgJwAM9RCIFAByCOAJg4h6AByiYCxAlCQJQADwRUA7DxABPDdoC+9VAENiplSADGEU5kxZcAXXqZiuiE-g5XIOwBG6BD8ADqhSChIALTWSu4ABADKpmDoAEL26AlgAK5I1gpKAPRQUugATuZQFZIgqAQV6IWKyvAgACrpdVVIANaYACJVMG3AxiBSpk1IxABKpv0IOqgjSR5eCMQVuegTHuX8TYWLzF4Acmjode6e14gTjl6F6KgIYKYQjtKy8q0AggFMFAILliPc1AYdPp4FouBNVqZmMwCEhmO9Po5jPgiGQNMJ6IwWGxODo+O1xJoAKyiABsdRkciKYxA6ngonEADoACzUQTc7k03m02lcWn0GHcqgcTlUjgcKjc2ncwSiCi0jjchHmSyIfymIIhdoRMgETDRAB8AFtpn1-pgAKqOVAACgAlDcNt5fPRegNhqZRioJlMZvNFn1liY1l6tjs9vQDvcQMcLGiLlcbsFmuC3vAPl90NGkSi0RjCz8mQCgSCwRDWQgOTLeVR+YLRMLReK9AgpTK5QqlSq1RqtdiQIQSORYZrCUxWOx4IIyXmQBxBFRRFQuAzfsyrGyO1weVwFWLRVQqDSuKIJQhaVpOVRaRvNJpBbTNCJadqLFZAsERzoCi7iVAAatMBAGl4TroO6np3NgPh+H6QwjGMIbTOgswLEs8ArDGdxxrs+y6Ic7SpqcGYYFmzy5uW3z1FUyKoui+aYkWkx7tWwKguCB6Ntyx5CWeIpcJe163j28APpoT4vlo75Up+36GOOk54vAFCiFSc7Eou3C8KuW5cO+9KVn8SgCbC2g8t+74drSohcFSVLcne8CaBwcmaMqb5nhyCm-rqoAAUaIARIMuhIKYVoENYADCSjbKYhTwPATQgeCFQQRUUEBDBjjwW4XpIT6KYRmhgYYdIWE4RGUZMYG6xEfA2wkYmZHJpR6boJcNFuNmLx5gWjGMpZSCArxdbWXCdkcJ+3KOc5rnudJXk+X5XnboFG4IsxpZsaNCY4lOlAiHpC4IMuRn8DQXBCRQu5VlZepspucluVSFAcBQ4kiluGoed5FA8oKYgcFSggauIVDBf+BqAe0SWzFUhQALKLEilQAJKzJUHzWOg6WZWa2W5flhVwR6JWIS4vqVQGQYPLVYa4ZG+HFjALWbG18akeRKY5lRfWZoNdGvAxnGIixZbsRWXEvZNNZ8fW72iJ9go-X9z5Oc+HDA5ooMCnK4hQzDCpqX4rzMN6oBJvw1i5O4UBWnUNoVH0lTrNMi4gGU2Hu7alQAKJIKuMiouwvD42jzIAOq4tOzm07zoDuBUUBe4nZ2wo8UC5BURP8JSNLmSAwKF0TAASiyoLzICiHUFgVLbfvrpu27N9Mbe1+HDdUHU5IgDb6DREJXAUFKRvLpog-0IsBA2vR8uMWYf56rcvM4BX2xZ8TADEARUMfAT0n4Zohw0Chy8djxDSvd+0PbXWO87xCu0Hnvey3fsB8o9APZewqGHCOUAo5D1jqlBOSdGw6C3vWDO+8c6aThm4AuRdkxCBEOIG4GCa51wbk3RMPd0B+1LnSburcyF93rsmeeIBh6j2iG5cSqpxBcDbHURey9Jar2ljqKwCDcC70zl7eAR8T4n3PrwTAV8-i3w4vfCWI0lHPxAA7doTsXZu0AcHCoPsKh-3KAAkAQDQ7h34JHWYkDsrQNaCg5O8DYybz3tnWBed0FV2TB3EyeDvG0KIVQtuJdtxmWCTQwh9Ch6rmYbyISrlvK0inuXHh5g+HHRMII1xrUd5IPEZI0+MjGFyOvqxKWyicwZLUS-QW2iP66LMfowxxjA56O-iAyx7RrHR0YVAloShHFwNTogtx6AhmeIrvg5MJlwleMwYEmZES-b3UessxZd0Yn8GYWqI2c9BT7J3AvJAS90mqIVuvEKu9cmiP3hI0+0iQAX1KQoo6aiK4P2qYWQwfgABuBB0AwBkEY6y2luScnXL9HS3IxDKQFB5aI1BwWTw7AKakP1NSaHoAALygJ-fCnJfL8goNSbgyoJ5OTUiYKCzAqhWnRmQ0wgxsmgAaKmVo-Auh1DAJnWYmNiDZSsAoYgDcUhpEyI4BIpMM7mA5QiRoOYCC-O9H4OIVorTYWIGVVVdgHAqomJfVQwLiAAAVFjBAAPImOIpxM4UAAifCvrbDor89SoFyJ8KW9AIConQC6wWvE+D0FHpjDp-rkz-zqHEaAtR2iFMeRMO1DqID9T9a62p3Vha9VTVGkENR+AHy4EW4tdQHXWD6LSgu4ckoxoLWAetDbS01AwBUGt+a43FpLfQAIzbKgdFIPFPoSAsBISmT6t4sjmWYEYOcrEhggA
```

Additionally, this PR introduces reversibility to the ContractManager, allowing contracts that are created and subsequently throw an exception to be reverted. This feature is particularly beneficial for factory contracts that can create a new DynamicContract and call functions within it. If an exception is thrown during this process, the new contract can now be properly removed from the contract map.