### PR TITLE
#52 Full support for Int safe types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ABI/
 build/
+testdump/
 debug.txt
+debug.log
 log.txt
 *.o
 *.gch

--- a/src/contract/CMakeLists.txt
+++ b/src/contract/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CONTRACT_HEADERS
   ${CMAKE_SOURCE_DIR}/src/contract/nativewrapper.h
   ${CMAKE_SOURCE_DIR}/src/contract/variables/reentrancyguard.h
   ${CMAKE_SOURCE_DIR}/src/contract/variables/safeuint.h
+  ${CMAKE_SOURCE_DIR}/src/contract/variables/safeint.h
   ${CMAKE_SOURCE_DIR}/src/contract/variables/safevector.h
   ${CMAKE_SOURCE_DIR}/src/contract/variables/safearray.h
   ${CMAKE_SOURCE_DIR}/src/contract/variables/safestring.h

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -850,10 +850,7 @@ Types inline getABIEnumFromString(const std::string& type) {
   class Decoder {
     private:
       /// List with the decoded native data types.
-      std::vector<std::variant<
-        uint256_t, std::vector<uint256_t>, Address, std::vector<Address>,
-        bool, std::vector<bool>, Bytes, std::vector<Bytes>, std::string, std::vector<std::string>
-      >> data_;
+      std::vector<BaseTypes> data_;
 
       /**
        * Decode a 256-bit unsigned integer from the given Solidity data string.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -1266,6 +1266,18 @@ Types inline getABIEnumFromString(const std::string& type) {
       ) const;
 
       /**
+        * Decode a 256-bit signed integer array from the given Solidity data
+        * string. Throws if data is too short.
+        * @param data The Solidity data bytes to decode.
+        * @param start The index of the vector to start decoding from.
+        * @return The decoded 256-bit signed integer array.
+        * @throw std::runtime_error if data is too short.
+        */
+      std::vector<int256_t> decodeInt256Arr(
+        const BytesArrView data, const uint64_t& start
+      ) const;
+
+      /**
        * Decode a 20-byte address array from the given Solidity data string.
        * Throws if data is too short.
        * @param data The Solidity data bytes to decode.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -1198,6 +1198,16 @@ Types inline getABIEnumFromString(const std::string& type) {
       uint256_t decodeUint256(const BytesArrView data, const uint64_t& start) const;
 
       /**
+      * Decode a 256-bit signed integer from the given Solidity data string.
+      * Throws if data is too short.
+      * @param data The Solidity data bytes to decode.
+      * @param start The index of the vector to start decoding from.
+      * @return The decoded 256-bit signed integer.
+      *@throw std::runtime_error if data is too short.
+      */
+      int256_t decodeInt256(const BytesArrView data, const uint64_t& start) const;
+
+      /**
        * Decode a 20-byte address from the given Solidity data string.
        * Throws if data is too short.
        * @param data The Solidity data bytes to decode.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -196,6 +196,9 @@ struct ABIType<Address> {
   static constexpr Types value = Types::address; ///< ABI type is address.
 };
 
+/**
+* Specialization for std::vector<Address>.
+*/
 template <>
 struct ABIType<std::vector<Address>> {
   static constexpr Types value = Types::addressArr; ///< ABI type is address.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -13,70 +13,8 @@ namespace ABI {
   /**
  * Enum for the types of Solidity variables.
  * Equivalency is as follows:
- * - uint8 = uint8 (Solidity) = uint8_t (C++)
- * - uint8Arr = uint8[] (Solidity) = std::vector<uint8_t> (C++)
- * - uint16 = uint16 (Solidity) = uint16_t (C++)
- * - uint16Arr = uint16[] (Solidity) = std::vector<uint16_t> (C++)
- * - uint24 = uint24 (Solidity) = uint24_t (C++)
-  * - uint24Arr = uint24[] (Solidity) = std::vector<uint24_t> (C++)
- * - uint32 = uint32 (Solidity) = uint32_t (C++)
- * - uint32Arr = uint32[] (Solidity) = std::vector<uint32_t> (C++)
- * - uint40 = uint40 (Solidity) = uint40_t (C++)
- * - uint40Arr = uint40[] (Solidity) = std::vector<uint40_t> (C++)
- * - uint48 = uint48 (Solidity) = uint48_t (C++)
- * - uint48Arr = uint48[] (Solidity) = std::vector<uint48_t> (C++)
- * - uint56 = uint56 (Solidity) = uint56_t (C++)
- * - uint56Arr = uint56[] (Solidity) = std::vector<uint56_t> (C++)
- * - uint64 = uint64 (Solidity) = uint64_t (C++)
- * - uint64Arr = uint64[] (Solidity) = std::vector<uint64_t> (C++)
- * - uint72 = uint72 (Solidity) = uint72_t (C++)
- * - uint72Arr = uint72[] (Solidity) = std::vector<uint72_t> (C++)
- * - uint80 = uint80 (Solidity) = uint80_t (C++)
- * - uint80Arr = uint80[] (Solidity) = std::vector<uint80_t> (C++)
- * - uint88 = uint88 (Solidity) = uint88_t (C++)
- * - uint88Arr = uint88[] (Solidity) = std::vector<uint88_t> (C++)
- * - uint96 = uint96 (Solidity) = uint96_t (C++)
- * - uint96Arr = uint96[] (Solidity) = std::vector<uint96_t> (C++)
- * - uint104 = uint104 (Solidity) = uint104_t (C++)
- * - uint104Arr = uint104[] (Solidity) = std::vector<uint104_t> (C++)
- * - uint112 = uint112 (Solidity) = uint112_t (C++)
- * - uint112Arr = uint112[] (Solidity) = std::vector<uint112_t> (C++)
- * - uint120 = uint120 (Solidity) = uint120_t (C++)
- * - uint120Arr = uint120[] (Solidity) = std::vector<uint120_t> (C++)
- * - uint128 = uint128 (Solidity) = uint128_t (C++)
- * - uint128Arr = uint128[] (Solidity) = std::vector<uint128_t> (C++)
- * - uint136 = uint136 (Solidity) = uint136_t (C++)
- * - uint136Arr = uint136[] (Solidity) = std::vector<uint136_t> (C++)
- * - uint144 = uint144 (Solidity) = uint144_t (C++)
- * - uint144Arr = uint144[] (Solidity) = std::vector<uint144_t> (C++)
- * - uint152 = uint152 (Solidity) = uint152_t (C++)
- * - uint152Arr = uint152[] (Solidity) = std::vector<uint152_t> (C++)
- * - uint160 = uint160 (Solidity) = uint160_t (C++)
- * - uint160Arr = uint160[] (Solidity) = std::vector<uint160_t> (C++)
- * - uint168 = uint168 (Solidity) = uint168_t (C++)
- * - uint168Arr = uint168[] (Solidity) = std::vector<uint168_t> (C++)
- * - uint176 = uint176 (Solidity) = uint176_t (C++)
- * - uint176Arr = uint176[] (Solidity) = std::vector<uint176_t> (C++)
- * - uint184 = uint184 (Solidity) = uint184_t (C++)
- * - uint184Arr = uint184[] (Solidity) = std::vector<uint184_t> (C++)
- * - uint192 = uint192 (Solidity) = uint192_t (C++)
- * - uint192Arr = uint192[] (Solidity) = std::vector<uint192_t> (C++)
- * - uint200 = uint200 (Solidity) = uint200_t (C++)
- * - uint200Arr = uint200[] (Solidity) = std::vector<uint200_t> (C++)
- * - uint208 = uint208 (Solidity) = uint208_t (C++)
- * - uint208Arr = uint208[] (Solidity) = std::vector<uint208_t> (C++)
- * - uint216 = uint216 (Solidity) = uint216_t (C++)
- * - uint216Arr = uint216[] (Solidity) = std::vector<uint216_t> (C++)
- * - uint224 = uint224 (Solidity) = uint224_t (C++)
- * - uint224Arr = uint224[] (Solidity) = std::vector<uint224_t> (C++)
- * - uint232 = uint232 (Solidity) = uint232_t (C++)
- * - uint232Arr = uint232[] (Solidity) = std::vector<uint232_t> (C++)
- * - uint240 = uint240 (Solidity) = uint240_t (C++)
- * - uint240Arr = uint240[] (Solidity) = std::vector<uint240_t> (C++)
- * - uint248 = uint248 (Solidity) = uint248_t (C++)
- * - uint248Arr = uint248[] (Solidity) = std::vector<uint248_t> (C++)
- * - uint256 = uint256 (Solidity) = uint256_t (C++)
- * - uint256Arr = uint256[] (Solidity) = std::vector<uint256_t> (C++)
+ * - uintn = uintn (Solidity) = uintn_t (C++), where n <= 256 and n % 8 == 0
+ * - uintnArr = uintn[] (Solidity) = std::vector<uintn_t> (C++), where n <= 256 and n % 8 == 0
  * - address = address (Solidity) = Address (C++)
  * - addressArr = address[] (Solidity) = std::vector<Address> (C++)
  * - bool = bool (Solidity) = bool (C++)
@@ -87,79 +25,78 @@ namespace ABI {
  * - stringArr = string[] (Solidity) = std::vector<std::string> (C++)
  */
 enum Types {
-  uint8,
-  uint8Arr,
-  uint16,
-  uint16Arr,
-  uint24,
-  uint24Arr,
-  uint32,
-  uint32Arr,
-  uint40,
-  uint40Arr,
-  uint48,
-  uint48Arr,
-  uint56,
-  uint56Arr,
-  uint64,
-  uint64Arr,
-  uint72,
-  uint72Arr,
-  uint80,
-  uint80Arr,
-  uint88,
-  uint88Arr,
-  uint96,
-  uint96Arr,
-  uint104,
-  uint104Arr,
-  uint112,
-  uint112Arr,
-  uint120,
-  uint120Arr,
-  uint128,
-  uint128Arr,
-  uint136,
-  uint136Arr,
-  uint144,
-  uint144Arr,
-  uint152,
-  uint152Arr,
-  uint160,
-  uint160Arr,
-  uint168,
-  uint168Arr,
-  uint176,
-  uint176Arr,
-  uint184,
-  uint184Arr,
-  uint192,
-  uint192Arr,
-  uint200,
-  uint200Arr,
-  uint208,
-  uint208Arr,
-  uint216,
-  uint216Arr,
-  uint224,
-  uint224Arr,
-  uint232,
-  uint232Arr,
-  uint240,
-  uint240Arr,
-  uint248,
-  uint248Arr,
-  uint256,
-  uint256Arr,
-  address,
-  addressArr,
-  boolean,
-  booleanArr,
-  bytes,
-  bytesArr,
-  string,
-  stringArr
+    uint8, uint8Arr,
+    uint16, uint16Arr,
+    uint24, uint24Arr,
+    uint32, uint32Arr,
+    uint40, uint40Arr,
+    uint48, uint48Arr,
+    uint56, uint56Arr,
+    uint64, uint64Arr,
+    uint72, uint72Arr,
+    uint80, uint80Arr,
+    uint88, uint88Arr,
+    uint96, uint96Arr,
+    uint104, uint104Arr,
+    uint112, uint112Arr,
+    uint120, uint120Arr,
+    uint128, uint128Arr,
+    uint136, uint136Arr,
+    uint144, uint144Arr,
+    uint152, uint152Arr,
+    uint160, uint160Arr,
+    uint168, uint168Arr,
+    uint176, uint176Arr,
+    uint184, uint184Arr,
+    uint192, uint192Arr,
+    uint200, uint200Arr,
+    uint208, uint208Arr,
+    uint216, uint216Arr,
+    uint224, uint224Arr,
+    uint232, uint232Arr,
+    uint240, uint240Arr,
+    uint248, uint248Arr,
+    uint256, uint256Arr,
+
+    int8, int8Arr,
+    int16, int16Arr,
+    int24, int24Arr,
+    int32, int32Arr,
+    int40, int40Arr,
+    int48, int48Arr,
+    int56, int56Arr,
+    int64, int64Arr,
+    int72, int72Arr,
+    int80, int80Arr,
+    int88, int88Arr,
+    int96, int96Arr,
+    int104, int104Arr,
+    int112, int112Arr,
+    int120, int120Arr,
+    int128, int128Arr,
+    int136, int136Arr,
+    int144, int144Arr,
+    int152, int152Arr,
+    int160, int160Arr,
+    int168, int168Arr,
+    int176, int176Arr,
+    int184, int184Arr,
+    int192, int192Arr,
+    int200, int200Arr,
+    int208, int208Arr,
+    int216, int216Arr,
+    int224, int224Arr,
+    int232, int232Arr,
+    int240, int240Arr,
+    int248, int248Arr,
+    int256, int256Arr,
+
+    address, addressArr,
+    boolean, booleanArr,
+    bytes, bytesArr,
+    string, stringArr
 };
+
 
 /**
 * Enum for the types of Solidity functions.
@@ -476,6 +413,262 @@ struct ABIType<uint248_t> {
   static constexpr Types value = Types::uint248; ///< ABI type is uint248.
 };
 
+/**
+* Specialization for int8_t.
+*/
+template <>
+struct ABIType<int8_t> {
+  static constexpr Types value = Types::int8; ///< ABI type is int8.
+};
+
+/**
+* Specialization for int16_t.
+*/
+template <>
+struct ABIType<int16_t> {
+  static constexpr Types value = Types::int16; ///< ABI type is int16.
+};
+
+/**
+* Specialization for int24_t.
+*/
+template <>
+struct ABIType<int24_t> {
+  static constexpr Types value = Types::int24; ///< ABI type is int24.
+};
+
+/**
+* Specialization for int32_t.
+*/
+template <>
+struct ABIType<int32_t> {
+  static constexpr Types value = Types::int32; ///< ABI type is int32.
+};
+
+/**
+* Specialization for int40_t.
+*/
+template <>
+struct ABIType<int40_t> {
+  static constexpr Types value = Types::int40; ///< ABI type is int40.
+};
+
+/**
+* Specialization for int48_t.
+*/
+template <>
+struct ABIType<int48_t> {
+  static constexpr Types value = Types::int48; ///< ABI type is int48.
+};
+
+/**
+* Specialization for int56_t.
+*/
+template <>
+struct ABIType<int56_t> {
+  static constexpr Types value = Types::int56; ///< ABI type is int56.
+};
+
+/**
+* Specialization for int64_t.
+*/
+template <>
+struct ABIType<int64_t> {
+  static constexpr Types value = Types::int64; ///< ABI type is int64.
+};
+
+/**
+* Specialization for int72_t.
+*/
+template <>
+struct ABIType<int72_t> {
+  static constexpr Types value = Types::int72; ///< ABI type is int72.
+};
+
+/**
+* Specialization for int80_t.
+*/
+template <>
+struct ABIType<int80_t> {
+  static constexpr Types value = Types::int80; ///< ABI type is int80.
+};
+
+/**
+* Specialization for int88_t.
+*/
+template <>
+struct ABIType<int88_t> {
+  static constexpr Types value = Types::int88; ///< ABI type is int88.
+};
+
+/**
+* Specialization for int96_t.
+*/
+template <>
+struct ABIType<int96_t> {
+  static constexpr Types value = Types::int96; ///< ABI type is int96.
+};
+
+/**
+* Specialization for int104_t.
+*/
+template <>
+struct ABIType<int104_t> {
+  static constexpr Types value = Types::int104; ///< ABI type is int104.
+};
+
+/**
+* Specialization for int112_t.
+*/
+template <>
+struct ABIType<int112_t> {
+  static constexpr Types value = Types::int112; ///< ABI type is int112.
+};
+
+/**
+* Specialization for int120_t.
+*/
+template <>
+struct ABIType<int120_t> {
+  static constexpr Types value = Types::int120; ///< ABI type is int120.
+};
+
+/**
+* Specialization for int128_t.
+*/
+template <>
+struct ABIType<int128_t> {
+  static constexpr Types value = Types::int128; ///< ABI type is int128.
+};
+
+/**
+* Specialization for int136_t.
+*/
+template <>
+struct ABIType<int136_t> {
+  static constexpr Types value = Types::int136; ///< ABI type is int136.
+};
+
+/**
+* Specialization for int144_t.
+*/
+template <>
+struct ABIType<int144_t> {
+  static constexpr Types value = Types::int144; ///< ABI type is int144.
+};
+
+/**
+* Specialization for int152_t.
+*/
+template <>
+struct ABIType<int152_t> {
+  static constexpr Types value = Types::int152; ///< ABI type is int152.
+};
+
+/**
+* Specialization for int160_t.
+*/
+template <>
+struct ABIType<int160_t> {
+  static constexpr Types value = Types::int160; ///< ABI type is int160.
+};
+
+/**
+* Specialization for int168_t.
+*/
+template <>
+struct ABIType<int168_t> {
+  static constexpr Types value = Types::int168; ///< ABI type is int168.
+};
+
+/**
+* Specialization for int176_t.
+*/
+template <>
+struct ABIType<int176_t> {
+  static constexpr Types value = Types::int176; ///< ABI type is int176.
+};
+
+/**
+* Specialization for int184_t.
+*/
+template <>
+struct ABIType<int184_t> {
+  static constexpr Types value = Types::int184; ///< ABI type is int184.
+};
+
+/**
+* Specialization for int192_t.
+*/
+template <>
+struct ABIType<int192_t> {
+  static constexpr Types value = Types::int192; ///< ABI type is int192.
+};
+
+/**
+* Specialization for int200_t.
+*/
+template <>
+struct ABIType<int200_t> {
+  static constexpr Types value = Types::int200; ///< ABI type is int200.
+};
+
+/**
+* Specialization for int208_t.
+*/
+template <>
+struct ABIType<int208_t> {
+  static constexpr Types value = Types::int208; ///< ABI type is int208.
+};
+
+/**
+* Specialization for int216_t.
+*/
+template <>
+struct ABIType<int216_t> {
+  static constexpr Types value = Types::int216; ///< ABI type is int216.
+};
+
+/**
+* Specialization for int224_t.
+*/
+template <>
+struct ABIType<int224_t> {
+  static constexpr Types value = Types::int224; ///< ABI type is int224.
+};
+
+/**
+* Specialization for int232_t.
+*/
+template <>
+struct ABIType<int232_t> {
+  static constexpr Types value = Types::int232; ///< ABI type is int232.
+};
+
+/**
+* Specialization for int240_t.
+*/
+template <>
+struct ABIType<int240_t> {
+  static constexpr Types value = Types::int240; ///< ABI type is int240.
+};
+
+/**
+* Specialization for int248_t.
+*/
+template <>
+struct ABIType<int248_t> {
+  static constexpr Types value = Types::int248; ///< ABI type is int248.
+};
+
+/**
+* Specialization for int256_t.
+*/
+template <>
+struct ABIType<int256_t> {
+  static constexpr Types value = Types::int256; ///< ABI type is int256.
+};
+
 
 /**
 * Struct to map a type to an ABI type.
@@ -622,6 +815,70 @@ std::string inline getStringFromABIEnum(Types type) {
     {Types::uint248Arr, "uint248[]"},
     {Types::uint256, "uint256"},
     {Types::uint256Arr, "uint256[]"},
+    {Types::int8, "int8"},
+    {Types::int8Arr, "int8[]"},
+    {Types::int16, "int16"},
+    {Types::int16Arr, "int16[]"},
+    {Types::int24, "int24"},
+    {Types::int24Arr, "int24[]"},
+    {Types::int32, "int32"},
+    {Types::int32Arr, "int32[]"},
+    {Types::int40, "int40"},
+    {Types::int40Arr, "int40[]"},
+    {Types::int48, "int48"},
+    {Types::int48Arr, "int48[]"},
+    {Types::int56, "int56"},
+    {Types::int56Arr, "int56[]"},
+    {Types::int64, "int64"},
+    {Types::int64Arr, "int64[]"},
+    {Types::int72, "int72"},
+    {Types::int72Arr, "int72[]"},
+    {Types::int80, "int80"},
+    {Types::int80Arr, "int80[]"},
+    {Types::int88, "int88"},
+    {Types::int88Arr, "int88[]"},
+    {Types::int96, "int96"},
+    {Types::int96Arr, "int96[]"},
+    {Types::int104, "int104"},
+    {Types::int104Arr, "int104[]"},
+    {Types::int112, "int112"},
+    {Types::int112Arr, "int112[]"},
+    {Types::int120, "int120"},
+    {Types::int120Arr, "int120[]"},
+    {Types::int128, "int128"},
+    {Types::int128Arr, "int128[]"},
+    {Types::int136, "int136"},
+    {Types::int136Arr, "int136[]"},
+    {Types::int144, "int144"},
+    {Types::int144Arr, "int144[]"},
+    {Types::int152, "int152"},
+    {Types::int152Arr, "int152[]"},
+    {Types::int160, "int160"},
+    {Types::int160Arr, "int160[]"},
+    {Types::int168, "int168"},
+    {Types::int168Arr, "int168[]"},
+    {Types::int176, "int176"},
+    {Types::int176Arr, "int176[]"},
+    {Types::int184, "int184"},
+    {Types::int184Arr, "int184[]"},
+    {Types::int192, "int192"},
+    {Types::int192Arr, "int192[]"},
+    {Types::int200, "int200"},
+    {Types::int200Arr, "int200[]"},
+    {Types::int208, "int208"},
+    {Types::int208Arr, "int208[]"},
+    {Types::int216, "int216"},
+    {Types::int216Arr, "int216[]"},
+    {Types::int224, "int224"},
+    {Types::int224Arr, "int224[]"},
+    {Types::int232, "int232"},
+    {Types::int232Arr, "int232[]"},
+    {Types::int240, "int240"},
+    {Types::int240Arr, "int240[]"},
+    {Types::int248, "int248"},
+    {Types::int248Arr, "int248[]"},
+    {Types::int256, "int256"},
+    {Types::int256Arr, "int256[]"},
     {Types::address, "address"},
     {Types::addressArr, "address[]"},
     {Types::boolean, "bool"},
@@ -711,6 +968,70 @@ Types inline getABIEnumFromString(const std::string& type) {
     {"uint248[]", Types::uint248Arr},
     {"uint256", Types::uint256},
     {"uint256[]", Types::uint256Arr},
+    {"int8", Types::int8},
+    {"int8[]", Types::int8Arr},
+    {"int16", Types::int16},
+    {"int16[]", Types::int16Arr},
+    {"int24", Types::int24},
+    {"int24[]", Types::int24Arr},
+    {"int32", Types::int32},
+    {"int32[]", Types::int32Arr},
+    {"int40", Types::int40},
+    {"int40[]", Types::int40Arr},
+    {"int48", Types::int48},
+    {"int48[]", Types::int48Arr},
+    {"int56", Types::int56},
+    {"int56[]", Types::int56Arr},
+    {"int64", Types::int64},
+    {"int64[]", Types::int64Arr},
+    {"int72", Types::int72},
+    {"int72[]", Types::int72Arr},
+    {"int80", Types::int80},
+    {"int80[]", Types::int80Arr},
+    {"int88", Types::int88},
+    {"int88[]", Types::int88Arr},
+    {"int96", Types::int96},
+    {"int96[]", Types::int96Arr},
+    {"int104", Types::int104},
+    {"int104[]", Types::int104Arr},
+    {"int112", Types::int112},
+    {"int112[]", Types::int112Arr},
+    {"int120", Types::int120},
+    {"int120[]", Types::int120Arr},
+    {"int128", Types::int128},
+    {"int128[]", Types::int128Arr},
+    {"int136", Types::int136},
+    {"int136[]", Types::int136Arr},
+    {"int144", Types::int144},
+    {"int144[]", Types::int144Arr},
+    {"int152", Types::int152},
+    {"int152[]", Types::int152Arr},
+    {"int160", Types::int160},
+    {"int160[]", Types::int160Arr},
+    {"int168", Types::int168},
+    {"int168[]", Types::int168Arr},
+    {"int176", Types::int176},
+    {"int176[]", Types::int176Arr},
+    {"int184", Types::int184},
+    {"int184[]", Types::int184Arr},
+    {"int192", Types::int192},
+    {"int192[]", Types::int192Arr},
+    {"int200", Types::int200},
+    {"int200[]", Types::int200Arr},
+    {"int208", Types::int208},
+    {"int208[]", Types::int208Arr},
+    {"int216", Types::int216},
+    {"int216[]", Types::int216Arr},
+    {"int224", Types::int224},
+    {"int224[]", Types::int224Arr},
+    {"int232", Types::int232},
+    {"int232[]", Types::int232Arr},
+    {"int240", Types::int240},
+    {"int240[]", Types::int240Arr},
+    {"int248", Types::int248},
+    {"int248[]", Types::int248Arr},
+    {"int256", Types::int256},
+    {"int256[]", Types::int256Arr},
     {"address", Types::address},
     {"address[]", Types::addressArr},
     {"bool", Types::boolean},
@@ -764,6 +1085,13 @@ Types inline getABIEnumFromString(const std::string& type) {
       Bytes encodeUint256(const uint256_t& num) const;
 
       /**
+      * Encode a 256-bit signed integer into Solidity ABI format.
+      * @param num The 256-bit signed integer to encode.
+      * @return The encoded int256 hex string, padded 32 hex bytes to the LEFT.
+      */
+      Bytes encodeInt256(const int256_t& num) const;
+
+      /**
        * Encode a 20-byte address into Solidity ABI format.
        * @param add The 20-byte address to encode.
        * @return The encoded address hex string, padded 32 bytes to the LEFT.
@@ -793,6 +1121,13 @@ Types inline getABIEnumFromString(const std::string& type) {
        * @return The encoded uint256[] hex string, with the proper offsets and lengths.
        */
       Bytes encodeUint256Arr(const std::vector<uint256_t>& numV) const;
+
+      /**
+       * Encode a 256-bit signed integer array into Solidity ABI format.
+       * @param numV The 256-bit signed integer array to encode.
+       * @return The encoded int256[] hex string, with the proper offsets and lengths.
+       */
+      Bytes encodeInt256Arr(const std::vector<int256_t>& numV) const;
 
       /**
        * Encode a 20-byte address array into Solidity ABI format.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -818,10 +818,7 @@ Types inline getABIEnumFromString(const std::string& type) {
 
     public:
       /// Alias for variant type, for easier handling.
-      typedef std::vector<std::variant<
-        uint256_t, std::vector<uint256_t>, Address, std::vector<Address>,
-        bool, std::vector<bool>, Bytes, BytesEncoded, std::vector<Bytes>, std::string, std::vector<std::string>
-      >> EncVar;
+      typedef std::vector<BaseTypes> EncVar;
 
       /**
        * Constructor.

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -708,9 +708,9 @@ template <typename T>
 struct TypeToEnum<const std::vector<T>&> : TypeToEnum<std::vector<T>> {};
 
 /**
-* Map for calling the correct ABI function for a given ABI type.
+* Map for calling the correct ABI function for a given uint type.
 */
-inline std::unordered_map<Types, std::function<std::any(uint256_t)>> castFunctions = {
+inline std::unordered_map<Types, std::function<std::any(uint256_t)>> castUintFunctions = {
     {Types::uint8, [](uint256_t value) { return std::any(static_cast<uint8_t>(value)); }},
     {Types::uint16, [](uint256_t value) { return std::any(static_cast<uint16_t>(value)); }},
     {Types::uint24, [](uint256_t value) { return std::any(static_cast<uint24_t>(value)); }},
@@ -742,6 +742,43 @@ inline std::unordered_map<Types, std::function<std::any(uint256_t)>> castFunctio
     {Types::uint232, [](uint256_t value) { return std::any(static_cast<uint232_t>(value)); }},
     {Types::uint240, [](uint256_t value) { return std::any(static_cast<uint240_t>(value)); }},
     {Types::uint248, [](uint256_t value) { return std::any(static_cast<uint248_t>(value)); }}
+  };
+
+  /**
+   * Map for calling the correct ABI function for a given int type.
+   */
+  inline std::unordered_map<Types, std::function<std::any(int256_t)>> castIntFunctions = {
+    {Types::int8, [](int256_t value) { return std::any(static_cast<int8_t>(value)); }},
+    {Types::int16, [](int256_t value) { return std::any(static_cast<int16_t>(value)); }},
+    {Types::int24, [](int256_t value) { return std::any(static_cast<int24_t>(value)); }},
+    {Types::int32, [](int256_t value) { return std::any(static_cast<int32_t>(value)); }},
+    {Types::int40, [](int256_t value) { return std::any(static_cast<int40_t>(value)); }},
+    {Types::int48, [](int256_t value) { return std::any(static_cast<int48_t>(value)); }},
+    {Types::int56, [](int256_t value) { return std::any(static_cast<int56_t>(value)); }},
+    {Types::int64, [](int256_t value) { return std::any(static_cast<int64_t>(value)); }},
+    {Types::int72, [](int256_t value) { return std::any(static_cast<int72_t>(value)); }},
+    {Types::int80, [](int256_t value) { return std::any(static_cast<int80_t>(value)); }},
+    {Types::int88, [](int256_t value) { return std::any(static_cast<int88_t>(value)); }},
+    {Types::int96, [](int256_t value) { return std::any(static_cast<int96_t>(value)); }},
+    {Types::int104, [](int256_t value) { return std::any(static_cast<int104_t>(value)); }},
+    {Types::int112, [](int256_t value) { return std::any(static_cast<int112_t>(value)); }},
+    {Types::int120, [](int256_t value) { return std::any(static_cast<int120_t>(value)); }},
+    {Types::int128, [](int256_t value) { return std::any(static_cast<int128_t>(value)); }},
+    {Types::int136, [](int256_t value) { return std::any(static_cast<int136_t>(value)); }},
+    {Types::int144, [](int256_t value) { return std::any(static_cast<int144_t>(value)); }},
+    {Types::int152, [](int256_t value) { return std::any(static_cast<int152_t>(value)); }},
+    {Types::int160, [](int256_t value) { return std::any(static_cast<int160_t>(value)); }},
+    {Types::int168, [](int256_t value) { return std::any(static_cast<int168_t>(value)); }},
+    {Types::int176, [](int256_t value) { return std::any(static_cast<int176_t>(value)); }},
+    {Types::int184, [](int256_t value) { return std::any(static_cast<int184_t>(value)); }},
+    {Types::int192, [](int256_t value) { return std::any(static_cast<int192_t>(value)); }},
+    {Types::int200, [](int256_t value) { return std::any(static_cast<int200_t>(value)); }},
+    {Types::int208, [](int256_t value) { return std::any(static_cast<int208_t>(value)); }},
+    {Types::int216, [](int256_t value) { return std::any(static_cast<int216_t>(value)); }},
+    {Types::int224, [](int256_t value) { return std::any(static_cast<int224_t>(value)); }},
+    {Types::int232, [](int256_t value) { return std::any(static_cast<int232_t>(value)); }},
+    {Types::int240, [](int256_t value) { return std::any(static_cast<int240_t>(value)); }},
+    {Types::int248, [](int256_t value) { return std::any(static_cast<int248_t>(value)); }}
   };
 
 /**
@@ -1388,12 +1425,105 @@ Types inline getABIEnumFromString(const std::string& type) {
         case Types::uint240:
         case Types::uint248:
         return this->getData<uint256_t>(index);
+        case Types::int256:
+        case Types::int8:
+        case Types::int16:
+        case Types::int24:
+        case Types::int32:
+        case Types::int40:
+        case Types::int48:
+        case Types::int56:
+        case Types::int64:
+        case Types::int72:
+        case Types::int80:
+        case Types::int88:
+        case Types::int96:
+        case Types::int104:
+        case Types::int112:
+        case Types::int120:
+        case Types::int128:
+        case Types::int136:
+        case Types::int144:
+        case Types::int152:
+        case Types::int160:
+        case Types::int168:
+        case Types::int176:
+        case Types::int184:
+        case Types::int192:
+        case Types::int200:
+        case Types::int208:
+        case Types::int216:
+        case Types::int224:
+        case Types::int232:
+        case Types::int240:
+        case Types::int248:
+        return this->getData<int256_t>(index);
         case Types::uint8Arr:
         case Types::uint16Arr:
+        case Types::uint24Arr:
         case Types::uint32Arr:
+        case Types::uint40Arr:
+        case Types::uint48Arr:
+        case Types::uint56Arr:
         case Types::uint64Arr:
+        case Types::uint72Arr:
+        case Types::uint80Arr:
+        case Types::uint88Arr:
+        case Types::uint96Arr:
+        case Types::uint104Arr:
+        case Types::uint112Arr:
+        case Types::uint120Arr:
+        case Types::uint128Arr:
+        case Types::uint136Arr:
+        case Types::uint144Arr:
+        case Types::uint152Arr:
+        case Types::uint160Arr:
+        case Types::uint168Arr:
+        case Types::uint176Arr:
+        case Types::uint184Arr:
+        case Types::uint192Arr:
+        case Types::uint200Arr:
+        case Types::uint208Arr:
+        case Types::uint216Arr:
+        case Types::uint224Arr:
+        case Types::uint232Arr:
+        case Types::uint240Arr:
+        case Types::uint248Arr:
         case Types::uint256Arr:
         return this->getData<std::vector<uint256_t>>(index);
+        case Types::int8Arr:
+        case Types::int16Arr:
+        case Types::int24Arr:
+        case Types::int32Arr:
+        case Types::int40Arr:
+        case Types::int48Arr:
+        case Types::int56Arr:
+        case Types::int64Arr:
+        case Types::int72Arr:
+        case Types::int80Arr:
+        case Types::int88Arr:
+        case Types::int96Arr:
+        case Types::int104Arr:
+        case Types::int112Arr:
+        case Types::int120Arr:
+        case Types::int128Arr:
+        case Types::int136Arr:
+        case Types::int144Arr:
+        case Types::int152Arr:
+        case Types::int160Arr:
+        case Types::int168Arr:
+        case Types::int176Arr:
+        case Types::int184Arr:
+        case Types::int192Arr:
+        case Types::int200Arr:
+        case Types::int208Arr:
+        case Types::int216Arr:
+        case Types::int224Arr:
+        case Types::int232Arr:
+        case Types::int240Arr:
+        case Types::int248Arr:
+        case Types::int256Arr:
+        return this->getData<std::vector<int256_t>>(index);
         case Types::address: return this->getData<Address>(index);
         case Types::addressArr: return this->getData<std::vector<Address>>(index);
         case Types::boolean: return this->getData<bool>(index);

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -115,15 +115,6 @@ struct ABIType {
   static constexpr Types value = Types::uint256; ///< Default ABI type is uint256.
 };
 
-/**
-* Specialization for std::vector<T>.
-* This is used for all vector types, including bytesArr and stringArr.
-* @tparam T The type to map to an ABI type.
-*/
-template <typename T>
-struct ABIType<std::vector<T>> {
-  static constexpr Types value = Types::uint256Arr; ///< ABI type is uint256Arr.
-};
 
 /**
 * Specialization for address.
@@ -667,6 +658,16 @@ struct ABIType<int248_t> {
 template <>
 struct ABIType<int256_t> {
   static constexpr Types value = Types::int256; ///< ABI type is int256.
+};
+
+/**
+* Specialization for std::vector<T>.
+* This is used for all vector types, including bytesArr and stringArr.
+* @tparam T The type to map to an ABI type.
+*/
+template <typename T>
+struct ABIType<std::vector<T>> {
+  static constexpr Types value = static_cast<Types>(static_cast<int>(ABIType<T>::value) + 1); ///< ABI type is vector of T.
 };
 
 

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -193,10 +193,15 @@ class ContractManager : BaseContract {
       std::vector<std::any> dataVector;
 
       for (size_t i = 0; i < types.size(); i++) {
-        if (ABI::castFunctions.count(types[i]) > 0) {
+        if (ABI::castUintFunctions.count(types[i]) > 0) {
           uint256_t value = std::any_cast<uint256_t>(decoder.getDataDispatch(i, types[i]));
-          dataVector.push_back(ABI::castFunctions[types[i]](value));
-        } else {
+          dataVector.push_back(ABI::castUintFunctions[types[i]](value));
+        }
+        else if (ABI::castIntFunctions.count(types[i]) > 0) {
+          int256_t value = std::any_cast<int256_t>(decoder.getDataDispatch(i, types[i]));
+          dataVector.push_back(ABI::castIntFunctions[types[i]](value));
+        }
+         else {
           dataVector.push_back(decoder.getDataDispatch(i, types[i]));
         }
       }

--- a/src/contract/dexv2/dexv2pair.cpp
+++ b/src/contract/dexv2/dexv2pair.cpp
@@ -122,9 +122,9 @@ std::pair<uint256_t, uint256_t> DEXV2Pair::getReservess() const {
 
 BytesEncoded DEXV2Pair::getReserves() const {
   ABI::Encoder::EncVar vars;
-  vars.push_back(this->reserve0_.get());
-  vars.push_back(this->reserve1_.get());
-  vars.push_back(this->blockTimestampLast_.get());
+  vars.push_back(static_cast<uint256_t>(this->reserve0_.get()));
+  vars.push_back(static_cast<uint256_t>(this->reserve1_.get()));
+  vars.push_back(static_cast<uint256_t>(this->blockTimestampLast_.get()));
   return BytesEncoded(ABI::Encoder(vars).getData());
 }
 

--- a/src/contract/dynamiccontract.h
+++ b/src/contract/dynamiccontract.h
@@ -312,10 +312,15 @@ class DynamicContract : public BaseContract {
         std::vector<std::any> dataVector;
 
       for (size_t i = 0; i < types.size(); i++) {
-        if (ABI::castFunctions.count(types[i]) > 0) {
+        if (ABI::castUintFunctions.count(types[i]) > 0) {
           uint256_t value = std::any_cast<uint256_t>(decoder.getDataDispatch(i, types[i]));
-          dataVector.push_back(ABI::castFunctions[types[i]](value));
-        } else {
+          dataVector.push_back(ABI::castUintFunctions[types[i]](value));
+        }
+        else if (ABI::castIntFunctions.count(types[i]) > 0) {
+          int256_t value = std::any_cast<int256_t>(decoder.getDataDispatch(i, types[i]));
+          dataVector.push_back(ABI::castIntFunctions[types[i]](value));
+        }
+         else {
           dataVector.push_back(decoder.getDataDispatch(i, types[i]));
         }
       }
@@ -360,10 +365,15 @@ class DynamicContract : public BaseContract {
         ABI::Decoder decoder(types, std::get<6>(callInfo));
         std::vector<std::any> dataVector;
       for (size_t i = 0; i < types.size(); i++) {
-        if (ABI::castFunctions.count(types[i]) > 0) {
+        if (ABI::castUintFunctions.count(types[i]) > 0) {
           uint256_t value = std::any_cast<uint256_t>(decoder.getDataDispatch(i, types[i]));
-          dataVector.push_back(ABI::castFunctions[types[i]](value));
-        } else {
+          dataVector.push_back(ABI::castUintFunctions[types[i]](value));
+        }
+        else if (ABI::castIntFunctions.count(types[i]) > 0) {
+          int256_t value = std::any_cast<int256_t>(decoder.getDataDispatch(i, types[i]));
+          dataVector.push_back(ABI::castIntFunctions[types[i]](value));
+        }
+        else {
           dataVector.push_back(decoder.getDataDispatch(i, types[i]));
         }
       }

--- a/src/contract/dynamiccontract.h
+++ b/src/contract/dynamiccontract.h
@@ -102,16 +102,6 @@ class DynamicContract : public BaseContract {
         }
     };
 
-    template<typename T, std::size_t N>
-    struct isRangedUint {
-        static const bool value = std::is_integral_v<T> && std::is_unsigned_v<T> && (sizeof(T) * 8 <= N);
-    };
-
-    template<typename T, std::size_t N>
-    struct isRangedInt {
-        static const bool value = std::is_integral_v<T> && std::is_signed_v<T> && (sizeof(T) * 8 <= N);
-    };
-
     /**
      * Template for registering a const member function with no arguments.
      * @param funcSignature Solidity function signature.
@@ -131,9 +121,9 @@ class DynamicContract : public BaseContract {
         {"view", [this, functStr, instance, memFunc, funcSignature]() {
           this->registerViewFunction(Utils::sha3(Utils::create_view_span(functStr)).view_const(0, 4), [instance, memFunc](const ethCallInfo &callInfo) -> BaseTypes {
             using ReturnType = decltype((instance->*memFunc)());
-            if constexpr (isRangedUint<ReturnType, 256>::value){
+            if constexpr (Utils::isRangedUint<ReturnType, 256>::value){
               return BaseTypes{static_cast<uint256_t>((instance->*memFunc)())};
-            } else if constexpr (isRangedInt<ReturnType, 256>::value){
+            } else if constexpr (Utils::isRangedInt<ReturnType, 256>::value){
               return BaseTypes{static_cast<int256_t>((instance->*memFunc)())};
             } else {
               return BaseTypes{(instance->*memFunc)()};
@@ -143,9 +133,9 @@ class DynamicContract : public BaseContract {
         {"nonpayable", [this, functStr, instance, memFunc, funcSignature]() {
           this->registerFunction(Utils::sha3(Utils::create_view_span(functStr)).view_const(0, 4), [instance, memFunc](const ethCallInfo &callInfo) -> BaseTypes {
             using ReturnType = decltype((instance->*memFunc)());
-            if constexpr (isRangedUint<ReturnType, 256>::value){
+            if constexpr (Utils::isRangedUint<ReturnType, 256>::value){
               return BaseTypes{static_cast<uint256_t>((instance->*memFunc)())};
-            } else if constexpr (isRangedInt<ReturnType, 256>::value){
+            } else if constexpr (Utils::isRangedInt<ReturnType, 256>::value){
               return BaseTypes{static_cast<int256_t>((instance->*memFunc)())};
             } else {
               return BaseTypes{(instance->*memFunc)()};
@@ -155,9 +145,9 @@ class DynamicContract : public BaseContract {
         {"payable", [this, functStr, instance, memFunc, funcSignature]() {
           this->registerPayableFunction(Utils::sha3(Utils::create_view_span(functStr)).view_const(0, 4), [instance, memFunc](const ethCallInfo &callInfo) -> BaseTypes {
             using ReturnType = decltype((instance->*memFunc)());
-            if constexpr (isRangedUint<ReturnType, 256>::value){
+            if constexpr (Utils::isRangedUint<ReturnType, 256>::value){
               return BaseTypes{static_cast<uint256_t>((instance->*memFunc)())};
-            } else if constexpr (isRangedInt<ReturnType, 256>::value){
+            } else if constexpr (Utils::isRangedInt<ReturnType, 256>::value){
               return BaseTypes{static_cast<int256_t>((instance->*memFunc)())};
             } else {
               return BaseTypes{(instance->*memFunc)()};

--- a/src/contract/variables/safeint.h
+++ b/src/contract/variables/safeint.h
@@ -973,9 +973,6 @@ public:
     */
     inline SafeInt_t<Size>& operator*=(const SafeInt_t<Size>& other) {
         check();
-        if (*valuePtr == 0 || other.get() == 0) {
-            throw std::domain_error("Multiplication assignment by zero.");
-        }
         if (*valuePtr > std::numeric_limits<int_t>::max() / other.get()) {
             throw std::overflow_error("Overflow in multiplication assignment operation.");
         }
@@ -994,9 +991,6 @@ public:
     */
     inline SafeInt_t<Size>& operator*=(const int_t& other) {
         check();
-        if (*valuePtr == 0 || other == 0) {
-            throw std::domain_error("Multiplication assignment by zero.");
-        }
         if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
             throw std::overflow_error("Overflow in multiplication assignment operation.");
         }
@@ -1017,9 +1011,6 @@ public:
     inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
     operator*=(const int_t& other) {
         check();
-        if (*valuePtr == 0 || other == 0) {
-            throw std::domain_error("Multiplication assignment by zero.");
-        }
         if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
             throw std::overflow_error("Overflow in multiplication assignment operation.");
         }

--- a/src/contract/variables/safeint.h
+++ b/src/contract/variables/safeint.h
@@ -148,26 +148,6 @@ public:
     }
 
     /**
-    * Addition operator.
-    * @param other The int_t to add.
-    * @throw std::overflow_error if an overflow happens.
-    * @throw std::underflow_error if an underflow happens.
-    * @return A new SafeInt_t with the result of the addition.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type 
-    operator+(const int_t& other) const {
-        check();
-        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
-            throw std::overflow_error("Overflow in addition operation.");
-        }
-        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
-            throw std::underflow_error("Underflow in addition operation.");
-        }
-        return SafeInt_t<Size>(*valuePtr + other);
-    }
-
-    /**
     * Subtraction operator.
     * @param other The SafeInt_t to subtract.
     * @throw std::overflow_error if an overflow happens.
@@ -193,26 +173,6 @@ public:
     * @return A new SafeInt_t with the result of the subtraction.
     */
     inline SafeInt_t<Size> operator-(const int_t& other) const {
-        check();
-        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
-            throw std::overflow_error("Overflow in subtraction operation.");
-        }
-        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
-            throw std::underflow_error("Underflow in subtraction operation.");
-        }
-        return SafeInt_t<Size>(*valuePtr - other);
-    }
-
-    /**
-    * Subtraction operator.
-    * @param other The int_t to subtract.
-    * @throw std::overflow_error if an overflow happens.
-    * @throw std::underflow_error if an underflow happens.
-    * @return A new SafeInt_t with the result of the subtraction.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator-(const int_t& other) const {
         check();
         if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
             throw std::overflow_error("Overflow in subtraction operation.");
@@ -268,30 +228,6 @@ public:
     }
 
     /**
-    * Multiplication operator.
-    * @param other The int_t to multiply.
-    * @throw std::overflow_error if an overflow happens.
-    * @throw std::underflow_error if an underflow happens.
-    * @throw std::domain_error if multiplying by 0.
-    * @return A new SafeInt_t with the result of the multiplication.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator*(const int_t& other) const {
-        check();
-        if (*valuePtr == 0 || other == 0) {
-            throw std::domain_error("Multiplication by zero.");
-        }
-        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
-            throw std::overflow_error("Overflow in multiplication operation.");
-        }
-        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
-            throw std::underflow_error("Underflow in multiplication operation.");
-        }
-        return SafeInt_t<Size>(*valuePtr * other);
-    }
-
-    /**
     * Division operator.
     * @param other The SafeInt_t to divide.
     * @throw std::domain_error if the other value is zero.
@@ -330,27 +266,6 @@ public:
     }
 
     /**
-    * Division operator.
-    * @param other The int_t to divide.
-    * @throw std::domain_error if the other value is zero.
-    * @throw std::overflow_error if division results in overflow.
-    * @return A new SafeInt_t with the result of the division.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator/(const int_t& other) const {
-        check();
-        if (other == 0) throw std::domain_error("Division by zero");
-
-        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
-        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
-            throw std::overflow_error("Overflow in division operation.");
-        }
-
-        return SafeInt_t<Size>(*valuePtr / other);
-    }
-
-    /**
     * Modulus operator.
     * @param other The SafeInt_t to take the modulus by.
     * @throw std::domain_error if the other value is zero.
@@ -370,21 +285,6 @@ public:
     * @return A new SafeInt_t with the result of the modulus.
     */
     inline SafeInt_t<Size> operator%(const int_t& other) const {
-        check();
-        if (other == 0) throw std::domain_error("Modulus by zero");
-
-        return SafeInt_t<Size>(*valuePtr % other);
-    }
-
-    /**
-    * Modulus operator.
-    * @param other The int_t to take the modulus by.
-    * @throw std::domain_error if the other value is zero.
-    * @return A new SafeInt_t with the result of the modulus.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator%(const int_t& other) const {
         check();
         if (other == 0) throw std::domain_error("Modulus by zero");
 
@@ -412,18 +312,6 @@ public:
     }
 
     /**
-    * Bitwise AND operator.
-    * @param other The int_t to AND.
-    * @return A new SafeInt_t with the result of the AND.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator&(const int_t& other) const {
-        check();
-        return SafeInt_t<Size>(*valuePtr & other);
-    }
-
-    /**
     * Bitwise OR operator.
     * @param other The SafeInt_t to OR.
     * @return A new SafeInt_t with the result of the OR.
@@ -439,18 +327,6 @@ public:
     * @return A new SafeInt_t with the result of the OR.
     */
     inline SafeInt_t<Size> operator|(const int_t& other) const {
-        check();
-        return SafeInt_t<Size>(*valuePtr | other);
-    }
-
-    /**
-    * Bitwise OR operator.
-    * @param other The int_t to OR.
-    * @return A new SafeInt_t with the result of the OR.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator|(const int_t& other) const {
         check();
         return SafeInt_t<Size>(*valuePtr | other);
     }
@@ -476,18 +352,6 @@ public:
     }
 
     /**
-    * Bitwise XOR operator.
-    * @param other The int_t to XOR.
-    * @return A new SafeInt_t with the result of the XOR.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator^(const int_t& other) const {
-        check();
-        return SafeInt_t<Size>(*valuePtr ^ other);
-    }
-
-    /**
     * Left shift operator.
     * @param other The SafeInt_t indicating the number of positions to shift.
     * @return A new SafeInt_t with the result of the shift.
@@ -508,18 +372,6 @@ public:
     }
 
     /**
-    * Left shift operator.
-    * @param other The int_t indicating the number of positions to shift.
-    * @return A new SafeInt_t with the result of the shift.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator<<(const int_t& other) const {
-        check();
-        return SafeInt_t<Size>(*valuePtr << other);
-    }
-
-    /**
     * Right shift operator.
     * @param other The SafeInt_t indicating the number of positions to shift.
     * @return A new SafeInt_t with the result of the shift.
@@ -535,18 +387,6 @@ public:
     * @return A new SafeInt_t with the result of the shift.
     */
     inline SafeInt_t<Size> operator>>(const int_t& other) const {
-        check();
-        return SafeInt_t<Size>(*valuePtr >> other);
-    }
-
-    /**
-    * Right shift operator.
-    * @param other The int_t indicating the number of positions to shift.
-    * @return A new SafeInt_t with the result of the shift.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
-    operator>>(const int_t& other) const {
         check();
         return SafeInt_t<Size>(*valuePtr >> other);
     }
@@ -581,18 +421,6 @@ public:
     }
 
     /**
-    * Logical AND operator.
-    * @param other The int_t to AND.
-    * @return True if both values are non-zero, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator&&(const int_t& other) const {
-        check();
-        return (*valuePtr && other);
-    }
-
-    /**
     * Logical OR operator.
     * @param other The SafeInt_t to OR.
     * @return True if either value is non-zero, false otherwise.
@@ -608,18 +436,6 @@ public:
     * @return True if either value is non-zero, false otherwise.
     */
     inline bool operator||(const int_t& other) const {
-        check();
-        return (*valuePtr || other);
-    }
-
-    /**
-    * Logical OR operator.
-    * @param other The int_t to OR.
-    * @return True if either value is non-zero, false otherwise.
-    */
-    template<typename T = int_t>    
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator||(const int_t& other) const {
         check();
         return (*valuePtr || other);
     }
@@ -645,18 +461,6 @@ public:
     }
 
     /**
-    * Equality operator.
-    * @param other The int_t to compare to.
-    * @return True if the values are equal, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator==(const int_t& other) const {
-        check();
-        return (*valuePtr == other);
-    }
-
-    /**
     * Inequality operator.
     * @param other The SafeInt_t to compare to.
     * @return True if the values are not equal, false otherwise.
@@ -672,18 +476,6 @@ public:
     * @return True if the values are not equal, false otherwise.
     */
     inline bool operator!=(const int_t& other) const {
-        check();
-        return (*valuePtr != other);
-    }
-
-    /**
-    * Inequality operator.
-    * @param other The int_t to compare to.
-    * @return True if the values are not equal, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator!=(const int_t& other) const {
         check();
         return (*valuePtr != other);
     }
@@ -709,18 +501,6 @@ public:
     }
 
     /**
-    * Less than operator.
-    * @param other The int_t to compare to.
-    * @return True if the value is less than the other value, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator<(const int_t& other) const {
-        check();
-        return (*valuePtr < other);
-    }
-
-    /**
     * Less than or equal to operator.
     * @param other The SafeInt_t to compare to.
     * @return True if the value is less than or equal to the other value, false otherwise.
@@ -736,18 +516,6 @@ public:
     * @return True if the value is less than or equal to the other value, false otherwise.
     */
     inline bool operator<=(const int_t& other) const {
-        check();
-        return (*valuePtr <= other);
-    }
-
-    /**
-    * Less than or equal to operator.
-    * @param other The int_t to compare to.
-    * @return True if the value is less than or equal to the other value, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator<=(const int_t& other) const {
         check();
         return (*valuePtr <= other);
     }
@@ -773,18 +541,6 @@ public:
     }
 
     /**
-    * Greater than operator.
-    * @param other The int_t to compare to.
-    * @return True if the value is greater than the other value, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator>(const int_t& other) const {
-        check();
-        return (*valuePtr > other);
-    }
-
-    /**
     * Greater than or equal to operator.
     * @param other The SafeInt_t to compare to.
     * @return True if the value is greater than or equal to the other value, false otherwise.
@@ -800,18 +556,6 @@ public:
     * @return True if the value is greater than or equal to the other value, false otherwise.
     */
     inline bool operator>=(const int_t& other) const {
-        check();
-        return (*valuePtr >= other);
-    }
-
-    /**
-    * Greater than or equal to operator.
-    * @param other The int_t to compare to.
-    * @return True if the value is greater than or equal to the other value, false otherwise.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
-    operator>=(const int_t& other) const {
         check();
         return (*valuePtr >= other);
     }
@@ -834,20 +578,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr = other;
-        return *this;
-    }
-
-    /**
-    * Assignment operator.
-    * @param other The int_t to assign.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator=(const int_t& other) {
         check();
         markAsUsed();
         *valuePtr = other;
@@ -878,26 +608,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator+=(const int_t& other) {
-        check();
-        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
-            throw std::overflow_error("Overflow in addition assignment operation.");
-        }
-        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
-            throw std::underflow_error("Underflow in addition assignment operation.");
-        }
-        markAsUsed();
-        *valuePtr += other;
-        return *this;
-    }
-
-    /**
-    * Addition assignment operator.
-    * @param other The int_t to add.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator+=(const int_t& other) {
         check();
         if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
             throw std::overflow_error("Overflow in addition assignment operation.");
@@ -947,26 +657,6 @@ public:
     }
 
     /**
-    * Subtraction assignment operator.
-    * @param other The int_t to subtract.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator-=(const int_t& other) {
-        check();
-        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
-            throw std::overflow_error("Overflow in subtraction assignment operation.");
-        }
-        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
-            throw std::underflow_error("Underflow in subtraction assignment operation.");
-        }
-        markAsUsed();
-        *valuePtr -= other;
-        return *this;
-    }
-
-    /**
     * Multiplication assignment operator.
     * @param other The SafeInt_t to multiply.
     * @return A reference to this SafeInt_t.
@@ -990,26 +680,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator*=(const int_t& other) {
-        check();
-        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
-            throw std::overflow_error("Overflow in multiplication assignment operation.");
-        }
-        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
-            throw std::underflow_error("Underflow in multiplication assignment operation.");
-        }
-        markAsUsed();
-        *valuePtr *= other;
-        return *this;
-    }
-
-    /**
-    * Multiplication assignment operator.
-    * @param other The int_t to multiply.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator*=(const int_t& other) {
         check();
         if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
             throw std::overflow_error("Overflow in multiplication assignment operation.");
@@ -1061,27 +731,6 @@ public:
     }
 
     /**
-    * Division assignment operator.
-    * @param other The int_t to divide.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator/=(const int_t& other) {
-        check();
-        if (other == 0) throw std::domain_error("Division assignment by zero.");
-
-        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
-        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
-            throw std::overflow_error("Overflow in division assignment operation.");
-        }
-
-        markAsUsed();
-        *valuePtr /= other;
-        return *this;
-    }
-
-    /**
     * Modulus assignment operator.
     * @param other The SafeInt_t to take the modulus by.
     * @return A reference to this SafeInt_t.
@@ -1100,21 +749,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator%=(const int_t& other) {
-        check();
-        if (other == 0) throw std::domain_error("Modulus assignment by zero.");
-        markAsUsed();
-        *valuePtr %= other;
-        return *this;
-    }
-
-    /**
-    * Modulus assignment operator.
-    * @param other The int_t to take the modulus by.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator%=(const int_t& other) {
         check();
         if (other == 0) throw std::domain_error("Modulus assignment by zero.");
         markAsUsed();
@@ -1147,20 +781,6 @@ public:
     }
 
     /**
-    * Bitwise AND assignment operator.
-    * @param other The int_t to AND.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator&=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr &= other;
-        return *this;
-    }
-
-    /**
     * Bitwise OR assignment operator.
     * @param other The SafeInt_t to OR.
     * @return A reference to this SafeInt_t.
@@ -1178,20 +798,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator|=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr |= other;
-        return *this;
-    }
-
-    /**
-    * Bitwise OR assignment operator.
-    * @param other The int_t to OR.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator|=(const int_t& other) {
         check();
         markAsUsed();
         *valuePtr |= other;
@@ -1223,20 +829,6 @@ public:
     }
 
     /**
-    * Bitwise XOR assignment operator.
-    * @param other The int_t to XOR.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator^=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr ^= other;
-        return *this;
-    }
-
-    /**
     * Left shift assignment operator.
     * @param other The SafeInt_t indicating the number of positions to shift.
     * @return A reference to this SafeInt_t.
@@ -1261,20 +853,6 @@ public:
     }
 
     /**
-    * Left shift assignment operator.
-    * @param other The int_t indicating the number of positions to shift.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator<<=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr <<= other;
-        return *this;
-    }
-
-    /**
     * Right shift assignment operator.
     * @param other The SafeInt_t indicating the number of positions to shift.
     * @return A reference to this SafeInt_t.
@@ -1292,20 +870,6 @@ public:
     * @return A reference to this SafeInt_t.
     */
     inline SafeInt_t<Size>& operator>>=(const int_t& other) {
-        check();
-        markAsUsed();
-        *valuePtr >>= other;
-        return *this;
-    }
-
-    /**
-    * Right shift assignment operator.
-    * @param other The int_t indicating the number of positions to shift.
-    * @return A reference to this SafeInt_t.
-    */
-    template<typename T = int_t>
-    inline typename std::enable_if<std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
-    operator>>=(const int_t& other) {
         check();
         markAsUsed();
         *valuePtr >>= other;

--- a/src/contract/variables/safeint.h
+++ b/src/contract/variables/safeint.h
@@ -1,0 +1,1339 @@
+#ifndef SAFEINT_T_H
+#define SAFEINT_T_H
+
+#include <memory>
+#include <boost/multiprecision/cpp_int.hpp>
+#include "safebase.h"
+
+/**
+* Template for the type of an int with the given size.
+* @tparam Size The size of the int.
+*/
+template <int Size>
+struct IntType {
+    using type = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+};
+
+template <>
+struct IntType<8> {
+    using type = int8_t;
+};
+
+template <>
+struct IntType<16> {
+    using type = int16_t;
+};
+
+template <>
+struct IntType<32> {
+    using type = int32_t;
+};
+
+template <>
+struct IntType<64> {
+    using type = int64_t;
+};
+
+template <int Size>
+class SafeInt_t : public SafeBase {
+private:
+    using int_t = typename IntType<Size>::type;
+    int_t value;
+    mutable std::unique_ptr<int_t> valuePtr;
+
+    inline void check() const override {
+        if (valuePtr == nullptr) valuePtr = std::make_unique<int_t>(value);
+    };
+
+public:
+    static_assert(Size >= 8 && Size <= 256 && Size % 8 == 0, "Size must be between 8 and 256 and a multiple of 8.");
+
+    SafeInt_t(DynamicContract* owner, const int_t& value = 0)
+      : SafeBase(owner), value(0), valuePtr(std::make_unique<int_t>(value))
+    {};
+
+    SafeInt_t(const int_t& value = 0)
+      : SafeBase(nullptr), value(0), valuePtr(std::make_unique<int_t>(value))
+    {};
+
+    SafeInt_t(const SafeInt_t<Size>& other) : SafeBase(nullptr) {
+      other.check(); value = 0; valuePtr = std::make_unique<int_t>(*other.valuePtr);
+    };
+
+    inline int_t get() const { check(); return *valuePtr; };
+
+    inline void commit() override { check(); value = *valuePtr; valuePtr = nullptr; registered = false; };
+
+    inline void revert() const override { valuePtr = nullptr; registered = false; };
+
+    /**
+    * Addition operator.
+    * @param other The SafeInt_t to add.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the addition.
+    */
+    inline SafeInt_t<Size> operator+(const SafeInt_t<Size>& other) const {
+        check();
+        if ((other.get() > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other.get())) {
+            throw std::overflow_error("Overflow in addition operation.");
+        }
+        if ((other.get() < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other.get())) {
+            throw std::underflow_error("Underflow in addition operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr + other.get());
+    }
+
+    /**
+    * Addition operator.
+    * @param other The int_t to add.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the addition.
+    */
+    inline SafeInt_t<Size> operator+(const int_t& other) const {
+        check();
+        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
+            throw std::overflow_error("Overflow in addition operation.");
+        }
+        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
+            throw std::underflow_error("Underflow in addition operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr + other);
+    }
+
+    /**
+    * Addition operator.
+    * @param other The int_t to add.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the addition.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type 
+    operator+(const int_t& other) const {
+        check();
+        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
+            throw std::overflow_error("Overflow in addition operation.");
+        }
+        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
+            throw std::underflow_error("Underflow in addition operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr + other);
+    }
+
+    /**
+    * Subtraction operator.
+    * @param other The SafeInt_t to subtract.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the subtraction.
+    */
+    inline SafeInt_t<Size> operator-(const SafeInt_t<Size>& other) const {
+        check();
+        if ((other.get() < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other.get())) {
+            throw std::overflow_error("Overflow in subtraction operation.");
+        }
+        if ((other.get() > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other.get())) {
+            throw std::underflow_error("Underflow in subtraction operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr - other.get());
+    }
+
+    /**
+    * Subtraction operator.
+    * @param other The int_t to subtract.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the subtraction.
+    */
+    inline SafeInt_t<Size> operator-(const int_t& other) const {
+        check();
+        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
+            throw std::overflow_error("Overflow in subtraction operation.");
+        }
+        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
+            throw std::underflow_error("Underflow in subtraction operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr - other);
+    }
+
+    /**
+    * Subtraction operator.
+    * @param other The int_t to subtract.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @return A new SafeInt_t with the result of the subtraction.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator-(const int_t& other) const {
+        check();
+        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
+            throw std::overflow_error("Overflow in subtraction operation.");
+        }
+        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
+            throw std::underflow_error("Underflow in subtraction operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr - other);
+    }
+
+    /**
+    * Multiplication operator.
+    * @param other The SafeInt_t to multiply.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @throw std::domain_error if multiplying by 0.
+    * @return A new SafeInt_t with the result of the multiplication.
+    */
+    inline SafeInt_t<Size> operator*(const SafeInt_t<Size>& other) const {
+        check();
+        if (*valuePtr == 0 || other.get() == 0) {
+            throw std::domain_error("Multiplication by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other.get()) {
+            throw std::overflow_error("Overflow in multiplication operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other.get()) {
+            throw std::underflow_error("Underflow in multiplication operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr * other.get());
+    }
+
+    /**
+    * Multiplication operator.
+    * @param other The int_t to multiply.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @throw std::domain_error if multiplying by 0.
+    * @return A new SafeInt_t with the result of the multiplication.
+    */
+    inline SafeInt_t<Size> operator*(const int_t& other) const {
+        check();
+        if (*valuePtr == 0 || other == 0) {
+            throw std::domain_error("Multiplication by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
+            throw std::overflow_error("Overflow in multiplication operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
+            throw std::underflow_error("Underflow in multiplication operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr * other);
+    }
+
+    /**
+    * Multiplication operator.
+    * @param other The int_t to multiply.
+    * @throw std::overflow_error if an overflow happens.
+    * @throw std::underflow_error if an underflow happens.
+    * @throw std::domain_error if multiplying by 0.
+    * @return A new SafeInt_t with the result of the multiplication.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator*(const int_t& other) const {
+        check();
+        if (*valuePtr == 0 || other == 0) {
+            throw std::domain_error("Multiplication by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
+            throw std::overflow_error("Overflow in multiplication operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
+            throw std::underflow_error("Underflow in multiplication operation.");
+        }
+        return SafeInt_t<Size>(*valuePtr * other);
+    }
+
+    /**
+    * Division operator.
+    * @param other The SafeInt_t to divide.
+    * @throw std::domain_error if the other value is zero.
+    * @throw std::overflow_error if division results in overflow.
+    * @return A new SafeInt_t with the result of the division.
+    */
+    inline SafeInt_t<Size> operator/(const SafeInt_t<Size>& other) const {
+        check();
+        if (other.get() == 0) throw std::domain_error("Division by zero");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other.get() == -1) {
+            throw std::overflow_error("Overflow in division operation.");
+        }
+
+        return SafeInt_t<Size>(*valuePtr / other.get());
+    }
+
+    /**
+    * Division operator.
+    * @param other The int_t to divide.
+    * @throw std::domain_error if the other value is zero.
+    * @throw std::overflow_error if division results in overflow.
+    * @return A new SafeInt_t with the result of the division.
+    */
+    inline SafeInt_t<Size> operator/(const int_t& other) const {
+        check();
+        if (other == 0) throw std::domain_error("Division by zero");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
+            throw std::overflow_error("Overflow in division operation.");
+        }
+
+        return SafeInt_t<Size>(*valuePtr / other);
+    }
+
+    /**
+    * Division operator.
+    * @param other The int_t to divide.
+    * @throw std::domain_error if the other value is zero.
+    * @throw std::overflow_error if division results in overflow.
+    * @return A new SafeInt_t with the result of the division.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator/(const int_t& other) const {
+        check();
+        if (other == 0) throw std::domain_error("Division by zero");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
+            throw std::overflow_error("Overflow in division operation.");
+        }
+
+        return SafeInt_t<Size>(*valuePtr / other);
+    }
+
+    /**
+    * Modulus operator.
+    * @param other The SafeInt_t to take the modulus by.
+    * @throw std::domain_error if the other value is zero.
+    * @return A new SafeInt_t with the result of the modulus.
+    */
+    inline SafeInt_t<Size> operator%(const SafeInt_t<Size>& other) const {
+        check();
+        if (other.get() == 0) throw std::domain_error("Modulus by zero");
+
+        return SafeInt_t<Size>(*valuePtr % other.get());
+    }
+
+    /**
+    * Modulus operator.
+    * @param other The int_t to take the modulus by.
+    * @throw std::domain_error if the other value is zero.
+    * @return A new SafeInt_t with the result of the modulus.
+    */
+    inline SafeInt_t<Size> operator%(const int_t& other) const {
+        check();
+        if (other == 0) throw std::domain_error("Modulus by zero");
+
+        return SafeInt_t<Size>(*valuePtr % other);
+    }
+
+    /**
+    * Modulus operator.
+    * @param other The int_t to take the modulus by.
+    * @throw std::domain_error if the other value is zero.
+    * @return A new SafeInt_t with the result of the modulus.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator%(const int_t& other) const {
+        check();
+        if (other == 0) throw std::domain_error("Modulus by zero");
+
+        return SafeInt_t<Size>(*valuePtr % other);
+    }
+
+    /**
+    * Bitwise AND operator.
+    * @param other The SafeInt_t to AND.
+    * @return A new SafeInt_t with the result of the AND.
+    */
+    inline SafeInt_t<Size> operator&(const SafeInt_t<Size>& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr & other.get());
+    }
+
+    /**
+    * Bitwise AND operator.
+    * @param other The int_t to AND.
+    * @return A new SafeInt_t with the result of the AND.
+    */
+    inline SafeInt_t<Size> operator&(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr & other);
+    }
+
+    /**
+    * Bitwise AND operator.
+    * @param other The int_t to AND.
+    * @return A new SafeInt_t with the result of the AND.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator&(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr & other);
+    }
+
+    /**
+    * Bitwise OR operator.
+    * @param other The SafeInt_t to OR.
+    * @return A new SafeInt_t with the result of the OR.
+    */
+    inline SafeInt_t<Size> operator|(const SafeInt_t<Size>& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr | other.get());
+    }
+
+    /**
+    * Bitwise OR operator.
+    * @param other The int_t to OR.
+    * @return A new SafeInt_t with the result of the OR.
+    */
+    inline SafeInt_t<Size> operator|(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr | other);
+    }
+
+    /**
+    * Bitwise OR operator.
+    * @param other The int_t to OR.
+    * @return A new SafeInt_t with the result of the OR.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator|(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr | other);
+    }
+
+    /**
+    * Bitwise XOR operator.
+    * @param other The SafeInt_t to XOR.
+    * @return A new SafeInt_t with the result of the XOR.
+    */
+    inline SafeInt_t<Size> operator^(const SafeInt_t<Size>& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr ^ other.get());
+    }
+
+    /**
+    * Bitwise XOR operator.
+    * @param other The int_t to XOR.
+    * @return A new SafeInt_t with the result of the XOR.
+    */
+    inline SafeInt_t<Size> operator^(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr ^ other);
+    }
+
+    /**
+    * Bitwise XOR operator.
+    * @param other The int_t to XOR.
+    * @return A new SafeInt_t with the result of the XOR.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator^(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr ^ other);
+    }
+
+    /**
+    * Left shift operator.
+    * @param other The SafeInt_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    inline SafeInt_t<Size> operator<<(const SafeInt_t<Size>& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr << other.get());
+    }
+
+    /**
+    * Left shift operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    inline SafeInt_t<Size> operator<<(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr << other);
+    }
+
+    /**
+    * Left shift operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator<<(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr << other);
+    }
+
+    /**
+    * Right shift operator.
+    * @param other The SafeInt_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    inline SafeInt_t<Size> operator>>(const SafeInt_t<Size>& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr >> other.get());
+    }
+
+    /**
+    * Right shift operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    inline SafeInt_t<Size> operator>>(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr >> other);
+    }
+
+    /**
+    * Right shift operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A new SafeInt_t with the result of the shift.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>>::type
+    operator>>(const int_t& other) const {
+        check();
+        return SafeInt_t<Size>(*valuePtr >> other);
+    }
+
+    /**
+    * Logical NOT operator.
+    * @return True if the value is zero, false otherwise.
+    */
+    inline bool operator!() const {
+        check();
+        return (!*valuePtr);
+    }
+
+    /**
+    * Logical AND operator.
+    * @param other The SafeInt_t to AND.
+    * @return True if both values are non-zero, false otherwise.
+    */
+    inline bool operator&&(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr && other.get());
+    }
+
+    /**
+    * Logical AND operator.
+    * @param other The int_t to AND.
+    * @return True if both values are non-zero, false otherwise.
+    */
+    inline bool operator&&(const int_t& other) const {
+        check();
+        return (*valuePtr && other);
+    }
+
+    /**
+    * Logical AND operator.
+    * @param other The int_t to AND.
+    * @return True if both values are non-zero, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator&&(const int_t& other) const {
+        check();
+        return (*valuePtr && other);
+    }
+
+    /**
+    * Logical OR operator.
+    * @param other The SafeInt_t to OR.
+    * @return True if either value is non-zero, false otherwise.
+    */
+    inline bool operator||(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr || other.get());
+    }
+
+    /**
+    * Logical OR operator.
+    * @param other The int_t to OR.
+    * @return True if either value is non-zero, false otherwise.
+    */
+    inline bool operator||(const int_t& other) const {
+        check();
+        return (*valuePtr || other);
+    }
+
+    /**
+    * Logical OR operator.
+    * @param other The int_t to OR.
+    * @return True if either value is non-zero, false otherwise.
+    */
+    template<typename T = int_t>    
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator||(const int_t& other) const {
+        check();
+        return (*valuePtr || other);
+    }
+
+    /**
+    * Equality operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the values are equal, false otherwise.
+    */
+    inline bool operator==(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr == other.get());
+    }
+
+    /**
+    * Equality operator.
+    * @param other The int_t to compare to.
+    * @return True if the values are equal, false otherwise.
+    */
+    inline bool operator==(const int_t& other) const {
+        check();
+        return (*valuePtr == other);
+    }
+
+    /**
+    * Equality operator.
+    * @param other The int_t to compare to.
+    * @return True if the values are equal, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator==(const int_t& other) const {
+        check();
+        return (*valuePtr == other);
+    }
+
+    /**
+    * Inequality operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the values are not equal, false otherwise.
+    */
+    inline bool operator!=(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr != other.get());
+    }
+
+    /**
+    * Inequality operator.
+    * @param other The int_t to compare to.
+    * @return True if the values are not equal, false otherwise.
+    */
+    inline bool operator!=(const int_t& other) const {
+        check();
+        return (*valuePtr != other);
+    }
+
+    /**
+    * Inequality operator.
+    * @param other The int_t to compare to.
+    * @return True if the values are not equal, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator!=(const int_t& other) const {
+        check();
+        return (*valuePtr != other);
+    }
+
+    /**
+    * Less than operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the value is less than the other value, false otherwise.
+    */
+    inline bool operator<(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr < other.get());
+    }
+
+    /**
+    * Less than operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is less than the other value, false otherwise.
+    */
+    inline bool operator<(const int_t& other) const {
+        check();
+        return (*valuePtr < other);
+    }
+
+    /**
+    * Less than operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is less than the other value, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator<(const int_t& other) const {
+        check();
+        return (*valuePtr < other);
+    }
+
+    /**
+    * Less than or equal to operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the value is less than or equal to the other value, false otherwise.
+    */
+    inline bool operator<=(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr <= other.get());
+    }
+
+    /**
+    * Less than or equal to operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is less than or equal to the other value, false otherwise.
+    */
+    inline bool operator<=(const int_t& other) const {
+        check();
+        return (*valuePtr <= other);
+    }
+
+    /**
+    * Less than or equal to operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is less than or equal to the other value, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator<=(const int_t& other) const {
+        check();
+        return (*valuePtr <= other);
+    }
+
+    /**
+    * Greater than operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the value is greater than the other value, false otherwise.
+    */
+    inline bool operator>(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr > other.get());
+    }
+
+    /**
+    * Greater than operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is greater than the other value, false otherwise.
+    */
+    inline bool operator>(const int_t& other) const {
+        check();
+        return (*valuePtr > other);
+    }
+
+    /**
+    * Greater than operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is greater than the other value, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator>(const int_t& other) const {
+        check();
+        return (*valuePtr > other);
+    }
+
+    /**
+    * Greater than or equal to operator.
+    * @param other The SafeInt_t to compare to.
+    * @return True if the value is greater than or equal to the other value, false otherwise.
+    */
+    inline bool operator>=(const SafeInt_t<Size>& other) const {
+        check();
+        return (*valuePtr >= other.get());
+    }
+
+    /**
+    * Greater than or equal to operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is greater than or equal to the other value, false otherwise.
+    */
+    inline bool operator>=(const int_t& other) const {
+        check();
+        return (*valuePtr >= other);
+    }
+
+    /**
+    * Greater than or equal to operator.
+    * @param other The int_t to compare to.
+    * @return True if the value is greater than or equal to the other value, false otherwise.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, bool>::type
+    operator>=(const int_t& other) const {
+        check();
+        return (*valuePtr >= other);
+    }
+
+    /**
+    * Assignment operator.
+    * @param other The SafeInt_t to assign.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr = other.get();
+        return *this;
+    }
+
+    /**
+    * Assignment operator.
+    * @param other The int_t to assign.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr = other;
+        return *this;
+    }
+
+    /**
+    * Assignment operator.
+    * @param other The int_t to assign.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr = other;
+        return *this;
+    }
+
+    /**
+    * Addition assignment operator.
+    * @param other The SafeInt_t to add.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator+=(const SafeInt_t<Size>& other) {
+        check();
+        if ((other.get() > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other.get())) {
+            throw std::overflow_error("Overflow in addition assignment operation.");
+        }
+        if ((other.get() < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other.get())) {
+            throw std::underflow_error("Underflow in addition assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr += other.get();
+        return *this;
+    }
+
+    /**
+    * Addition assignment operator.
+    * @param other The int_t to add.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator+=(const int_t& other) {
+        check();
+        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
+            throw std::overflow_error("Overflow in addition assignment operation.");
+        }
+        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
+            throw std::underflow_error("Underflow in addition assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr += other;
+        return *this;
+    }
+
+    /**
+    * Addition assignment operator.
+    * @param other The int_t to add.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator+=(const int_t& other) {
+        check();
+        if ((other > 0) && (*valuePtr > std::numeric_limits<int_t>::max() - other)) {
+            throw std::overflow_error("Overflow in addition assignment operation.");
+        }
+        if ((other < 0) && (*valuePtr < std::numeric_limits<int_t>::min() - other)) {
+            throw std::underflow_error("Underflow in addition assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr += other;
+        return *this;
+    }
+
+    /**
+    * Subtraction assignment operator.
+    * @param other The SafeInt_t to subtract.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator-=(const SafeInt_t<Size>& other) {
+        check();
+        if ((other.get() < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other.get())) {
+            throw std::overflow_error("Overflow in subtraction assignment operation.");
+        }
+        if ((other.get() > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other.get())) {
+            throw std::underflow_error("Underflow in subtraction assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr -= other.get();
+        return *this;
+    }
+
+    /**
+    * Subtraction assignment operator.
+    * @param other The int_t to subtract.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator-=(const int_t& other) {
+        check();
+        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
+            throw std::overflow_error("Overflow in subtraction assignment operation.");
+        }
+        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
+            throw std::underflow_error("Underflow in subtraction assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr -= other;
+        return *this;
+    }
+
+    /**
+    * Subtraction assignment operator.
+    * @param other The int_t to subtract.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator-=(const int_t& other) {
+        check();
+        if ((other < 0) && (*valuePtr > std::numeric_limits<int_t>::max() + other)) {
+            throw std::overflow_error("Overflow in subtraction assignment operation.");
+        }
+        if ((other > 0) && (*valuePtr < std::numeric_limits<int_t>::min() + other)) {
+            throw std::underflow_error("Underflow in subtraction assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr -= other;
+        return *this;
+    }
+
+    /**
+    * Multiplication assignment operator.
+    * @param other The SafeInt_t to multiply.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator*=(const SafeInt_t<Size>& other) {
+        check();
+        if (*valuePtr == 0 || other.get() == 0) {
+            throw std::domain_error("Multiplication assignment by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other.get()) {
+            throw std::overflow_error("Overflow in multiplication assignment operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other.get()) {
+            throw std::underflow_error("Underflow in multiplication assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr *= other.get();
+        return *this;
+    }
+
+    /**
+    * Multiplication assignment operator.
+    * @param other The int_t to multiply.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator*=(const int_t& other) {
+        check();
+        if (*valuePtr == 0 || other == 0) {
+            throw std::domain_error("Multiplication assignment by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
+            throw std::overflow_error("Overflow in multiplication assignment operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
+            throw std::underflow_error("Underflow in multiplication assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr *= other;
+        return *this;
+    }
+
+    /**
+    * Multiplication assignment operator.
+    * @param other The int_t to multiply.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator*=(const int_t& other) {
+        check();
+        if (*valuePtr == 0 || other == 0) {
+            throw std::domain_error("Multiplication assignment by zero.");
+        }
+        if (*valuePtr > std::numeric_limits<int_t>::max() / other) {
+            throw std::overflow_error("Overflow in multiplication assignment operation.");
+        }
+        if (*valuePtr < std::numeric_limits<int_t>::min() / other) {
+            throw std::underflow_error("Underflow in multiplication assignment operation.");
+        }
+        markAsUsed();
+        *valuePtr *= other;
+        return *this;
+    }
+
+    /**
+    * Division assignment operator.
+    * @param other The SafeInt_t to divide.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator/=(const SafeInt_t<Size>& other) {
+        check();
+        if (other.get() == 0) throw std::domain_error("Division assignment by zero.");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other.get() == -1) {
+            throw std::overflow_error("Overflow in division assignment operation.");
+        }
+
+        markAsUsed();
+        *valuePtr /= other.get();
+        return *this;
+    }
+
+    /**
+    * Division assignment operator.
+    * @param other The int_t to divide.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator/=(const int_t& other) {
+        check();
+        if (other == 0) throw std::domain_error("Division assignment by zero.");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
+            throw std::overflow_error("Overflow in division assignment operation.");
+        }
+
+        markAsUsed();
+        *valuePtr /= other;
+        return *this;
+    }
+
+    /**
+    * Division assignment operator.
+    * @param other The int_t to divide.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator/=(const int_t& other) {
+        check();
+        if (other == 0) throw std::domain_error("Division assignment by zero.");
+
+        // Handling the edge case where dividing the smallest negative number by -1 causes overflow
+        if (*valuePtr == std::numeric_limits<int_t>::min() && other == -1) {
+            throw std::overflow_error("Overflow in division assignment operation.");
+        }
+
+        markAsUsed();
+        *valuePtr /= other;
+        return *this;
+    }
+
+    /**
+    * Modulus assignment operator.
+    * @param other The SafeInt_t to take the modulus by.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator%=(const SafeInt_t<Size>& other) {
+        check();
+        if (other.get() == 0) throw std::domain_error("Modulus assignment by zero.");
+        markAsUsed();
+        *valuePtr %= other.get();
+        return *this;
+    }
+
+    /**
+    * Modulus assignment operator.
+    * @param other The int_t to take the modulus by.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator%=(const int_t& other) {
+        check();
+        if (other == 0) throw std::domain_error("Modulus assignment by zero.");
+        markAsUsed();
+        *valuePtr %= other;
+        return *this;
+    }
+
+    /**
+    * Modulus assignment operator.
+    * @param other The int_t to take the modulus by.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator%=(const int_t& other) {
+        check();
+        if (other == 0) throw std::domain_error("Modulus assignment by zero.");
+        markAsUsed();
+        *valuePtr %= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise AND assignment operator.
+    * @param other The SafeInt_t to AND.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator&=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr &= other.get();
+        return *this;
+    }
+
+    /**
+    * Bitwise AND assignment operator.
+    * @param other The int_t to AND.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator&=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr &= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise AND assignment operator.
+    * @param other The int_t to AND.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator&=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr &= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise OR assignment operator.
+    * @param other The SafeInt_t to OR.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator|=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr |= other.get();
+        return *this;
+    }
+
+    /**
+    * Bitwise OR assignment operator.
+    * @param other The int_t to OR.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator|=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr |= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise OR assignment operator.
+    * @param other The int_t to OR.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator|=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr |= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise XOR assignment operator.
+    * @param other The SafeInt_t to XOR.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator^=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr ^= other.get();
+        return *this;
+    }
+
+    /**
+    * Bitwise XOR assignment operator.
+    * @param other The int_t to XOR.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator^=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr ^= other;
+        return *this;
+    }
+
+    /**
+    * Bitwise XOR assignment operator.
+    * @param other The int_t to XOR.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<!std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator^=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr ^= other;
+        return *this;
+    }
+
+    /**
+    * Left shift assignment operator.
+    * @param other The SafeInt_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator<<=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr <<= other.get();
+        return *this;
+    }
+
+    /**
+    * Left shift assignment operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator<<=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr <<= other;
+        return *this;
+    }
+
+    /**
+    * Left shift assignment operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator<<=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr <<= other;
+        return *this;
+    }
+
+    /**
+    * Right shift assignment operator.
+    * @param other The SafeInt_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator>>=(const SafeInt_t<Size>& other) {
+        check();
+        markAsUsed();
+        *valuePtr >>= other.get();
+        return *this;
+    }
+
+    /**
+    * Right shift assignment operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator>>=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr >>= other;
+        return *this;
+    }
+
+    /**
+    * Right shift assignment operator.
+    * @param other The int_t indicating the number of positions to shift.
+    * @return A reference to this SafeInt_t.
+    */
+    template<typename T = int_t>
+    inline typename std::enable_if<std::is_same<T, int64_t>::value, SafeInt_t<Size>&>::type
+    operator>>=(const int_t& other) {
+        check();
+        markAsUsed();
+        *valuePtr >>= other;
+        return *this;
+    }
+
+    /**
+    * Prefix increment operator.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator++() {
+        check();
+        if (*valuePtr == std::numeric_limits<int_t>::max()) {
+            throw std::overflow_error("Overflow in prefix increment operation.");
+        }
+        markAsUsed();
+        ++(*valuePtr);
+        return *this;
+    }
+
+    /**
+    * Postfix increment operator.
+    * @return A new SafeInt_t with the value of this SafeInt_t before the increment.
+    */
+    inline SafeInt_t<Size> operator++(int) {
+        check();
+        if (*valuePtr == std::numeric_limits<int_t>::max()) {
+            throw std::overflow_error("Overflow in postfix increment operation.");
+        }
+        markAsUsed();
+        SafeInt_t<Size> temp(*valuePtr);
+        ++(*valuePtr);
+        return temp;
+    }
+
+    /**
+    * Prefix decrement operator.
+    * @return A reference to this SafeInt_t.
+    */
+    inline SafeInt_t<Size>& operator--() {
+        check();
+        if (*valuePtr == std::numeric_limits<int_t>::min()) {
+            throw std::underflow_error("Underflow in prefix decrement operation.");
+        }
+        markAsUsed();
+        --(*valuePtr);
+        return *this;
+    }
+
+    /**
+    * Postfix decrement operator.
+    * @return A new SafeInt_t with the value of this SafeInt_t before the decrement.
+    */
+    inline SafeInt_t<Size> operator--(int) {
+        check();
+        if (*valuePtr == std::numeric_limits<int_t>::min()) {
+            throw std::underflow_error("Underflow in postfix decrement operation.");
+        }
+        markAsUsed();
+        SafeInt_t<Size> temp(*valuePtr);
+        --(*valuePtr);
+        return temp;
+    }
+
+}; // class SafeInt_t
+
+#endif // SAFEINT_T_H

--- a/src/contract/variables/safeint.h
+++ b/src/contract/variables/safeint.h
@@ -11,36 +11,58 @@
 */
 template <int Size>
 struct IntType {
+    /**
+    * The type of the int.
+    */
     using type = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<Size, Size, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
 };
 
+/**
+* Template specialization for int8_t.
+*/
 template <>
 struct IntType<8> {
-    using type = int8_t;
+    using type = int8_t; ///< int8_t type.
 };
 
+/**
+* Template specialization for int16_t.
+*/
 template <>
 struct IntType<16> {
-    using type = int16_t;
+    using type = int16_t;  ///< int16_t type.
 };
 
+/**
+* Template specialization for int32_t.
+*/
 template <>
 struct IntType<32> {
-    using type = int32_t;
+    using type = int32_t; ///< int32_t type.
 };
 
+/**
+* Template specialization for int64_t.
+*/
 template <>
 struct IntType<64> {
-    using type = int64_t;
+    using type = int64_t; ///< int64_t type.
 };
 
+/**
+* SafeInt_t class template.
+* @tparam Size The size of the int.
+*/
 template <int Size>
 class SafeInt_t : public SafeBase {
 private:
-    using int_t = typename IntType<Size>::type;
-    int_t value;
-    mutable std::unique_ptr<int_t> valuePtr;
+    using int_t = typename IntType<Size>::type; ///< The type of the int.
+    int_t value; ///< The value of the int.
+    mutable std::unique_ptr<int_t> valuePtr; ///< The pointer to the value of the int.
 
+    /**
+    * Check if the value is registered and if not, register it.
+    */
     inline void check() const override {
         if (valuePtr == nullptr) valuePtr = std::make_unique<int_t>(value);
     };
@@ -48,22 +70,45 @@ private:
 public:
     static_assert(Size >= 8 && Size <= 256 && Size % 8 == 0, "Size must be between 8 and 256 and a multiple of 8.");
 
+    /**
+    * Constructor.
+    * @param owner The DynamicContract that owns this variable.
+    * @param value The initial value of the variable.
+    */
     SafeInt_t(DynamicContract* owner, const int_t& value = 0)
       : SafeBase(owner), value(0), valuePtr(std::make_unique<int_t>(value))
     {};
 
+    /**
+    * Constructor.
+    * @param value The initial value of the variable.
+    */
     SafeInt_t(const int_t& value = 0)
       : SafeBase(nullptr), value(0), valuePtr(std::make_unique<int_t>(value))
     {};
 
+    /**
+    * Copy constructor.
+    * @param other The SafeInt_t to copy.
+    */
     SafeInt_t(const SafeInt_t<Size>& other) : SafeBase(nullptr) {
       other.check(); value = 0; valuePtr = std::make_unique<int_t>(*other.valuePtr);
     };
 
+    /**
+    * Getter for the value.
+    * @return The value.
+    */
     inline int_t get() const { check(); return *valuePtr; };
 
+    /**
+    * Commit the value.
+    */
     inline void commit() override { check(); value = *valuePtr; valuePtr = nullptr; registered = false; };
 
+    /**
+    * Revert the value.
+    */
     inline void revert() const override { valuePtr = nullptr; registered = false; };
 
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,21 @@
 #include <iostream>
+#include "contract/abi.h"
 #include "src/core/blockchain.h"
 #include <filesystem>
+#include "src/contract/abi.h"
+#include "src/utils/utils.h"
+#include "utils/utils.h"
 
 int main() {
-  Utils::logToCout = true;
-  std::string blockchainPath = std::filesystem::current_path().string() + std::string("/blockchain");
-  Blockchain blockchain(blockchainPath);
-  /// Start the blockchain syncing engine.
-  blockchain.start();
-  std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours(std::numeric_limits<int>::max()));
+
+  ABI::Encoder::EncVar vars;
+  int8_t a = -10;
+  vars.push_back(static_cast<int256_t>(a));
+  auto result = ABI::Encoder(vars).getData();
+  std::cout << Hex::fromBytes(result).get() << std::endl;
+  auto decodeResult = ABI::Decoder({ABI::Types::int8}, result).getData<int256_t>(0);
+  std::cout << decodeResult << std::endl;
   return 0;
+  
+  
 }

--- a/src/utils/contractreflectioninterface.h
+++ b/src/utils/contractreflectioninterface.h
@@ -163,6 +163,12 @@ void inline registerContract(const std::vector<std::string> &ctorArgs,
                     uint144_t, uint152_t, uint160_t, uint168_t, uint176_t,
                     uint184_t, uint192_t, uint200_t, uint208_t, uint216_t,
                     uint224_t, uint232_t, uint240_t, uint248_t, uint256_t,
+                    int8_t, int16_t, int24_t, int32_t, int40_t, int48_t, int56_t,
+                    int64_t, int72_t, int80_t, int88_t, int96_t, int104_t,
+                    int112_t, int120_t, int128_t, int136_t, int144_t, int152_t,
+                    int160_t, int168_t, int176_t, int184_t, int192_t, int200_t,
+                    int208_t, int216_t, int224_t, int232_t, int240_t, int248_t,
+                    int256_t,
                     Address, bool, std::string, Bytes>(typeMap);
     }
     populateMethodArgumentsTypesMap<TContract>();

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -71,7 +71,7 @@ int Hex::toInt(char c) {
 std::string Hex::forRPC() const {
   std::string retHex = this->hex;
   if (retHex[0] != '0' && retHex[1] != 'x') retHex.insert(0, "0x");
-  if (retHex == "0x") { return retHex; };
+  if (retHex == "0x") { retHex ="0x0"; return retHex; };
   // Check for leading zeroes!
   size_t i = 2;
   while (retHex[i] == '0') retHex.erase(i, 1);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -675,6 +675,39 @@ int256_t Utils::bytesToInt256(const BytesArrView b) {
     }
 }
 
+BytesArr<32> Utils::int256ToBytes(const int256_t& i) {
+    BytesArr<32> ret;
+
+    if (i < 0) {
+        int256_t absValue = -i;
+
+        Bytes tempBytes;
+        boost::multiprecision::export_bits(absValue, std::back_inserter(tempBytes), 8);
+        for (int j = 0; j < 32; j++) {
+            if (j < tempBytes.size()) {
+                ret[31 - j] = ~tempBytes[tempBytes.size() - j - 1];
+            } else {
+                ret[31 - j] = 0xFF;
+            }
+        }
+        for (int j = 31; j >= 0; j--) {
+            if (ret[j] != 0xFF) {
+                ret[j]++;
+                break;
+            } else {
+                ret[j] = 0x00;
+            }
+        }
+    } else {
+        Bytes tempBytes;
+        boost::multiprecision::export_bits(i, std::back_inserter(tempBytes), 8);
+        std::copy(tempBytes.rbegin(), tempBytes.rend(), ret.rbegin());
+    }
+
+    return ret;
+}
+
+
 
 Bytes Utils::randBytes(const int& size) {
   Bytes bytes(size, 0x00);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -6,6 +6,10 @@ std::mutex cout_mutex;
 
 std::atomic<bool> Utils::logToCout = false;
 
+std::string Utils::getTestDumpPath() {
+  return std::string("testdump");
+}
+
 void fail(const std::string& cl, std::string&& func, boost::beast::error_code ec, const char* what) {
   Logger::logToDebug(LogType::ERROR, cl, std::move(func), std::string("HTTP Fail ") + what + " : " + ec.message());
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -281,6 +281,8 @@ struct Account {
 /// Namespace for utility functions.
 namespace Utils {
 
+  std::string getTestDumpPath(); ///< Get the path to the test dump folder.
+
   /**
   * Template for identifying if a type is a tuple.
   * @tparam T The type to check.

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -232,42 +232,13 @@ template <std::size_t N> using BytesArr = std::array<Byte, N>; ///< Typedef for 
 using BytesArrView = std::span<const Byte, std::dynamic_extent>; ///< Typedef for BytesArrView.
 using BytesArrMutableView = std::span<Byte, std::dynamic_extent>; ///< Typedef for BytesArrMutableView.
 
-using BaseTypes = std::variant<
-      int8_t, uint8_t, std::vector<int8_t>,
-      int16_t, uint16_t, std::vector<int16_t>, std::vector<uint16_t>,
-      int24_t, uint24_t, std::vector<int24_t>, std::vector<uint24_t>,
-      int32_t, uint32_t, std::vector<int32_t>, std::vector<uint32_t>,
-      int40_t, uint40_t, std::vector<int40_t>, std::vector<uint40_t>,
-      int48_t, uint48_t, std::vector<int48_t>, std::vector<uint48_t>,
-      int56_t, uint56_t, std::vector<int56_t>, std::vector<uint56_t>,
-      int64_t, uint64_t, std::vector<int64_t>, std::vector<uint64_t>,
-      int72_t, uint72_t, std::vector<int72_t>, std::vector<uint72_t>,
-      int80_t, uint80_t, std::vector<int80_t>, std::vector<uint80_t>,
-      int88_t, uint88_t, std::vector<int88_t>, std::vector<uint88_t>,
-      int96_t, uint96_t, std::vector<int96_t>, std::vector<uint96_t>,
-      int104_t, uint104_t, std::vector<int104_t>, std::vector<uint104_t>,
-      int112_t, uint112_t, std::vector<int112_t>, std::vector<uint112_t>,
-      int120_t, uint120_t, std::vector<int120_t>, std::vector<uint120_t>,
-      int128_t, uint128_t, std::vector<int128_t>, std::vector<uint128_t>,
-      int136_t, uint136_t, std::vector<int136_t>, std::vector<uint136_t>,
-      int144_t, uint144_t, std::vector<int144_t>, std::vector<uint144_t>,
-      int152_t, uint152_t, std::vector<int152_t>, std::vector<uint152_t>,
-      int160_t, uint160_t, std::vector<int160_t>, std::vector<uint160_t>,
-      int168_t, uint168_t, std::vector<int168_t>, std::vector<uint168_t>,
-      int176_t, uint176_t, std::vector<int176_t>, std::vector<uint176_t>,
-      int184_t, uint184_t, std::vector<int184_t>, std::vector<uint184_t>,
-      int192_t, uint192_t, std::vector<int192_t>, std::vector<uint192_t>,
-      int200_t, uint200_t, std::vector<int200_t>, std::vector<uint200_t>,
-      int208_t, uint208_t, std::vector<int208_t>, std::vector<uint208_t>,
-      int216_t, uint216_t, std::vector<int216_t>, std::vector<uint216_t>,
-      int224_t, uint224_t, std::vector<int224_t>, std::vector<uint224_t>,
-      int232_t, uint232_t, std::vector<int232_t>, std::vector<uint232_t>,
-      int240_t, uint240_t, std::vector<int240_t>, std::vector<uint240_t>,
-      int248_t, uint248_t, std::vector<int248_t>, std::vector<uint248_t>,
-      int256_t, uint256_t, std::vector<int256_t>, std::vector<uint256_t>,
-      Address, std::vector<Address>,
-      bool, std::vector<bool>, Bytes, BytesEncoded, std::vector<Bytes>, std::string, std::vector<std::string>
-  >; ///< Typedef for SolidityArg.
+/**
+* Typedef for all the possible types that can be used in a function.
+* Based on Solidity types.
+* @note: Fixed point types are not supported yet, because they are not supported fully in Solidity.
+*/
+using BaseTypes = std::variant<uint256_t, std::vector<uint256_t>, Address, std::vector<Address>,
+        bool, std::vector<bool>, Bytes, BytesEncoded, std::vector<Bytes>, std::string, std::vector<std::string>>;
 
 /**
  * ethCallInfo: tuple of (from, to, gasLimit, gasPrice, value, functor, data).

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -292,6 +292,26 @@ namespace Utils {
   std::string getTestDumpPath(); ///< Get the path to the test dump folder.
 
   /**
+  * Template for identifying if a type is a uint between 8 and 256 bits.
+  * @tparam T The type to check.
+  * @tparam N The number of bits.
+  */
+  template<typename T, std::size_t N>
+    struct isRangedUint {
+        static const bool value = std::is_integral_v<T> && std::is_unsigned_v<T> && (sizeof(T) * 8 <= N); ///< Indicates whether the type is a uint between 8 and 256 bits.
+    };
+
+  /**
+  * Template for identifying if a type is an int between 8 and 256 bits.
+  * @tparam T The type to check.
+  * @tparam N The number of bits.
+  */
+  template<typename T, std::size_t N>
+  struct isRangedInt {
+      static const bool value = std::is_integral_v<T> && std::is_signed_v<T> && (sizeof(T) * 8 <= N); ///< Indicates whether the type is an int between 8 and 256 bits.
+  };
+
+  /**
   * Template for identifying if a type is a tuple.
   * @tparam T The type to check.
   */

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -25,6 +25,7 @@
 
 #include "json.hpp"
 #include "src/contract/variables/safeuint.h"
+#include "src/contract/variables/safeint.h"
 
 /// @file utils.h
 
@@ -42,87 +43,117 @@ using Bytes = std::vector<Byte>; ///< Typedef for Bytes.
 
 /// Typedef for uint24_t.
 using uint24_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<24, 24, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint40_t.
 using uint40_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<40, 40, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint48_t.
 using uint48_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<48, 48, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint56_t.
 using uint56_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<56, 56, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint72_t.
 using uint72_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<72, 72, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint80_t.
 using uint80_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<80, 80, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint88_t.
 using uint88_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<88, 88, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint96_t.
 using uint96_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<96, 96, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint104_t.
 using uint104_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<104, 104, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint112_t.
 using uint112_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<112, 112, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint120_t.  
 using uint120_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<120, 120, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint128_t.
 using uint128_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<128, 128, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint136_t.
 using uint136_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<136, 136, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint144_t.
 using uint144_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<144, 144, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint152_t.
 using uint152_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<152, 152, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint160_t.
 using uint160_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<160, 160, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint168_t.
 using uint168_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<168, 168, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint176_t.
 using uint176_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<176, 176, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint184_t.
 using uint184_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<184, 184, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint192_t.
 using uint192_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<192, 192, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint200_t.
 using uint200_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<200, 200, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint208_t.
 using uint208_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<208, 208, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint216_t.
 using uint216_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<216, 216, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint224_t.
 using uint224_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<224, 224, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint232_t.
 using uint232_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<232, 232, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint240_t.
 using uint240_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<240, 240, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint248_t.
 using uint248_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<248, 248, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
-
 /// Typedef for uint256_t.
 using uint256_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+
+/// Typedef for int24_t.
+using int24_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<24, 24, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int40_t.
+using int40_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<40, 40, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int48_t.
+using int48_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<48, 48, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int56_t.
+using int56_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<56, 56, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int72_t.
+using int72_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<72, 72, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int80_t.
+using int80_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<80, 80, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int88_t.
+using int88_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<88, 88, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int96_t.
+using int96_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<96, 96, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int104_t.
+using int104_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<104, 104, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int112_t.
+using int112_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<112, 112, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int120_t.
+using int120_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<120, 120, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int128_t.
+using int128_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<128, 128, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int136_t.
+using int136_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<136, 136, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int144_t.
+using int144_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<144, 144, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int152_t.
+using int152_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<152, 152, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int160_t.
+using int160_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<160, 160, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int168_t.
+using int168_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<168, 168, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int176_t.
+using int176_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<176, 176, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int184_t.
+using int184_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<184, 184, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int192_t.
+using int192_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<192, 192, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int200_t.
+using int200_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<200, 200, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int208_t.
+using int208_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<208, 208, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int216_t.
+using int216_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<216, 216, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int224_t.
+using int224_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<224, 224, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int232_t.
+using int232_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<232, 232, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int240_t.
+using int240_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<240, 240, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int248_t.
+using int248_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<248, 248, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+/// Typedef for int256_t.
+using int256_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::signed_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
 
 using SafeUint8_t = SafeUint_t<8>; ///< Typedef for SafeUint8_t.
 using SafeUint16_t = SafeUint_t<16>; ///< Typedef for SafeUint16_t.
@@ -156,6 +187,39 @@ using SafeUint232_t = SafeUint_t<232>; ///< Typedef for SafeUint232_t.
 using SafeUint240_t = SafeUint_t<240>; ///< Typedef for SafeUint240_t.
 using SafeUint248_t = SafeUint_t<248>; ///< Typedef for SafeUint248_t.
 using SafeUint256_t = SafeUint_t<256>; ///< Typedef for SafeUint256_t.
+
+using SafeInt8_t = SafeInt_t<8>; ///< Typedef for SafeInt8_t.
+using SafeInt16_t = SafeInt_t<16>; ///< Typedef for SafeInt16_t.
+using SafeInt24_t = SafeInt_t<24>; ///< Typedef for SafeInt24_t.
+using SafeInt32_t = SafeInt_t<32>; ///< Typedef for SafeInt32_t.
+using SafeInt40_t = SafeInt_t<40>; ///< Typedef for SafeInt40_t.
+using SafeInt48_t = SafeInt_t<48>; ///< Typedef for SafeInt48_t.
+using SafeInt56_t = SafeInt_t<56>; ///< Typedef for SafeInt56_t.
+using SafeInt64_t = SafeInt_t<64>; ///< Typedef for SafeInt64_t.
+using SafeInt72_t = SafeInt_t<72>; ///< Typedef for SafeInt72_t.
+using SafeInt80_t = SafeInt_t<80>; ///< Typedef for SafeInt80_t.
+using SafeInt88_t = SafeInt_t<88>; ///< Typedef for SafeInt88_t.
+using SafeInt96_t = SafeInt_t<96>; ///< Typedef for SafeInt96_t.
+using SafeInt104_t = SafeInt_t<104>; ///< Typedef for SafeInt104_t.
+using SafeInt112_t = SafeInt_t<112>; ///< Typedef for SafeInt112_t.
+using SafeInt120_t = SafeInt_t<120>; ///< Typedef for SafeInt120_t.
+using SafeInt128_t = SafeInt_t<128>; ///< Typedef for SafeInt128_t.
+using SafeInt136_t = SafeInt_t<136>; ///< Typedef for SafeInt136_t.
+using SafeInt144_t = SafeInt_t<144>; ///< Typedef for SafeInt144_t.
+using SafeInt152_t = SafeInt_t<152>; ///< Typedef for SafeInt152_t.
+using SafeInt160_t = SafeInt_t<160>; ///< Typedef for SafeInt160_t.
+using SafeInt168_t = SafeInt_t<168>; ///< Typedef for SafeInt168_t.
+using SafeInt176_t = SafeInt_t<176>; ///< Typedef for SafeInt176_t.
+using SafeInt184_t = SafeInt_t<184>; ///< Typedef for SafeInt184_t.
+using SafeInt192_t = SafeInt_t<192>; ///< Typedef for SafeInt192_t.
+using SafeInt200_t = SafeInt_t<200>; ///< Typedef for SafeInt200_t.
+using SafeInt208_t = SafeInt_t<208>; ///< Typedef for SafeInt208_t.
+using SafeInt216_t = SafeInt_t<216>; ///< Typedef for SafeInt216_t.
+using SafeInt224_t = SafeInt_t<224>; ///< Typedef for SafeInt224_t.
+using SafeInt232_t = SafeInt_t<232>; ///< Typedef for SafeInt232_t.
+using SafeInt240_t = SafeInt_t<240>; ///< Typedef for SafeInt240_t.
+using SafeInt248_t = SafeInt_t<248>; ///< Typedef for SafeInt248_t.
+using SafeInt256_t = SafeInt_t<256>; ///< Typedef for SafeInt256_t.
 
 /**
 * Struct for Bytes type that will be encoded in an function return.

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -232,6 +232,43 @@ template <std::size_t N> using BytesArr = std::array<Byte, N>; ///< Typedef for 
 using BytesArrView = std::span<const Byte, std::dynamic_extent>; ///< Typedef for BytesArrView.
 using BytesArrMutableView = std::span<Byte, std::dynamic_extent>; ///< Typedef for BytesArrMutableView.
 
+using BaseTypes = std::variant<
+      int8_t, uint8_t, std::vector<int8_t>,
+      int16_t, uint16_t, std::vector<int16_t>, std::vector<uint16_t>,
+      int24_t, uint24_t, std::vector<int24_t>, std::vector<uint24_t>,
+      int32_t, uint32_t, std::vector<int32_t>, std::vector<uint32_t>,
+      int40_t, uint40_t, std::vector<int40_t>, std::vector<uint40_t>,
+      int48_t, uint48_t, std::vector<int48_t>, std::vector<uint48_t>,
+      int56_t, uint56_t, std::vector<int56_t>, std::vector<uint56_t>,
+      int64_t, uint64_t, std::vector<int64_t>, std::vector<uint64_t>,
+      int72_t, uint72_t, std::vector<int72_t>, std::vector<uint72_t>,
+      int80_t, uint80_t, std::vector<int80_t>, std::vector<uint80_t>,
+      int88_t, uint88_t, std::vector<int88_t>, std::vector<uint88_t>,
+      int96_t, uint96_t, std::vector<int96_t>, std::vector<uint96_t>,
+      int104_t, uint104_t, std::vector<int104_t>, std::vector<uint104_t>,
+      int112_t, uint112_t, std::vector<int112_t>, std::vector<uint112_t>,
+      int120_t, uint120_t, std::vector<int120_t>, std::vector<uint120_t>,
+      int128_t, uint128_t, std::vector<int128_t>, std::vector<uint128_t>,
+      int136_t, uint136_t, std::vector<int136_t>, std::vector<uint136_t>,
+      int144_t, uint144_t, std::vector<int144_t>, std::vector<uint144_t>,
+      int152_t, uint152_t, std::vector<int152_t>, std::vector<uint152_t>,
+      int160_t, uint160_t, std::vector<int160_t>, std::vector<uint160_t>,
+      int168_t, uint168_t, std::vector<int168_t>, std::vector<uint168_t>,
+      int176_t, uint176_t, std::vector<int176_t>, std::vector<uint176_t>,
+      int184_t, uint184_t, std::vector<int184_t>, std::vector<uint184_t>,
+      int192_t, uint192_t, std::vector<int192_t>, std::vector<uint192_t>,
+      int200_t, uint200_t, std::vector<int200_t>, std::vector<uint200_t>,
+      int208_t, uint208_t, std::vector<int208_t>, std::vector<uint208_t>,
+      int216_t, uint216_t, std::vector<int216_t>, std::vector<uint216_t>,
+      int224_t, uint224_t, std::vector<int224_t>, std::vector<uint224_t>,
+      int232_t, uint232_t, std::vector<int232_t>, std::vector<uint232_t>,
+      int240_t, uint240_t, std::vector<int240_t>, std::vector<uint240_t>,
+      int248_t, uint248_t, std::vector<int248_t>, std::vector<uint248_t>,
+      int256_t, uint256_t, std::vector<int256_t>, std::vector<uint256_t>,
+      Address, std::vector<Address>,
+      bool, std::vector<bool>, Bytes, BytesEncoded, std::vector<Bytes>, std::string, std::vector<std::string>
+  >; ///< Typedef for SolidityArg.
+
 /**
  * ethCallInfo: tuple of (from, to, gasLimit, gasPrice, value, functor, data).
  * **ATTENTION**: Be aware that we are using BytesArrView, so you MUST

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -237,7 +237,7 @@ using BytesArrMutableView = std::span<Byte, std::dynamic_extent>; ///< Typedef f
 * Based on Solidity types.
 * @note: Fixed point types are not supported yet, because they are not supported fully in Solidity.
 */
-using BaseTypes = std::variant<uint256_t, std::vector<uint256_t>, Address, std::vector<Address>,
+using BaseTypes = std::variant<uint256_t, std::vector<uint256_t>, int256_t, std::vector<int256_t>, Address, std::vector<Address>,
         bool, std::vector<bool>, Bytes, BytesEncoded, std::vector<Bytes>, std::string, std::vector<std::string>>;
 
 /**

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -862,6 +862,14 @@ namespace Utils {
    */
    uint8_t bytesToUint8(const BytesArrView b);
 
+   /**
+    * Convert a bytes string to a 256-bit signed integer.
+    * @param b The bytes string to convert.
+    * @return The converted 256-bit integer.
+    * @throw std::runtime_error if string size is invalid.
+    */
+  int256_t bytesToInt256(const BytesArrView b);
+
   /**
    * Add padding to the left of a byte vector.
    * @param bytes The vector to pad.

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -355,6 +355,14 @@ namespace Utils {
   BytesArr<32> uint256ToBytes(const uint256_t& i);
 
   /**
+   * Convert a 256-bit signed integer to a bytes string.
+   * Use `Hex()` to properly print it.
+   * @param i The integer to convert.
+   * @return The converted 256-bit integer as a bytes string.
+   */
+  BytesArr<32> int256ToBytes(const int256_t& i);
+
+  /**
   * Convert a 248-bit unsigned integer to a bytes string.
   * Use `Hex()` to properly print it.
   * @param i The integer to convert.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set (TESTS_SOURCES
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeuint_t_c++.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeint_t_c++.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeuint_t_boost.cpp
+  ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeint_t_boost.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safestring.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeaddress.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeunorderedmap.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set (TESTS_SOURCES
   ${CMAKE_SOURCE_DIR}/tests/contract/contractabigenerator.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/dexv2.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeuint_t_c++.cpp
+  ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeint_t_c++.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeuint_t_boost.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safestring.cpp
   ${CMAKE_SOURCE_DIR}/tests/contract/variables/safeaddress.cpp

--- a/tests/contract/contractmanager.cpp
+++ b/tests/contract/contractmanager.cpp
@@ -10,11 +10,12 @@
 ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
 
 namespace TContractManager {
+  std::string testDumpPath = Utils::getTestDumpPath();
   // TODO: Add more testcases for ContractManager once it's integrated with State.
   TEST_CASE("ContractManager class", "[contract][contractmanager]") {
     SECTION("ContractManager createNewContractERC20Contract()") {
-      if (std::filesystem::exists("ContractManagerTestCreateNew")) {
-        std::filesystem::remove_all("ContractManagerTestCreateNew");
+      if (std::filesystem::exists(testDumpPath + "/ContractManagerTestCreateNew")) {
+        std::filesystem::remove_all(testDumpPath + "/ContractManagerTestCreateNew");
       }
 
       PrivKey privKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
@@ -25,8 +26,8 @@ namespace TContractManager {
       uint256_t tokenSupply = 1000000000000000000;
 
       {
-        std::unique_ptr options = std::make_unique<Options>(Options::fromFile("ContractManagerTestCreateNew"));
-        std::unique_ptr db = std::make_unique<DB>("ContractManagerTestCreateNew");
+        std::unique_ptr options = std::make_unique<Options>(Options::fromFile(testDumpPath + "/ContractManagerTestCreateNew"));
+        std::unique_ptr db = std::make_unique<DB>(testDumpPath + "/ContractManagerTestCreateNew");
         std::unique_ptr<rdPoS> rdpos;
         ContractManager contractManager(nullptr, db, rdpos, options);
 
@@ -83,8 +84,8 @@ namespace TContractManager {
         REQUIRE(getBalanceMeDecoder.getData<uint256_t>(0) == tokenSupply);
       }
 
-      std::unique_ptr options = std::make_unique<Options>(Options::fromFile("ContractManagerTestCreateNew"));
-      std::unique_ptr db = std::make_unique<DB>("ContractManagerTestCreateNew");
+      std::unique_ptr options = std::make_unique<Options>(Options::fromFile(testDumpPath + "/ContractManagerTestCreateNew"));
+      std::unique_ptr db = std::make_unique<DB>(testDumpPath + "/ContractManagerTestCreateNew");
       std::unique_ptr<rdPoS> rdpos;
       ContractManager contractManager(nullptr, db, rdpos, options);
 
@@ -99,8 +100,8 @@ namespace TContractManager {
     }
 
     SECTION("ContractManager createNewContractERC20ContractTransferTo()") {
-      if (std::filesystem::exists("ContractManagerTestCreateNew")) {
-        std::filesystem::remove_all("ContractManagerTestCreateNew");
+      if (std::filesystem::exists(testDumpPath + "/ContractManagerTestCreateNew")) {
+        std::filesystem::remove_all(testDumpPath + "/ContractManagerTestCreateNew");
       }
 
       PrivKey privKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
@@ -112,8 +113,8 @@ namespace TContractManager {
       uint256_t tokenSupply = 1000000000000000000;
 
       {
-        std::unique_ptr options = std::make_unique<Options>(Options::fromFile("ContractManagerTestCreateNew"));
-        std::unique_ptr db = std::make_unique<DB>("ContractManagerTestCreateNew");
+        std::unique_ptr options = std::make_unique<Options>(Options::fromFile(testDumpPath + "/ContractManagerTestCreateNew"));
+        std::unique_ptr db = std::make_unique<DB>(testDumpPath + "/ContractManagerTestCreateNew");
         std::unique_ptr<rdPoS> rdpos;
         ContractManager contractManager(nullptr, db, rdpos, options);
 
@@ -182,8 +183,8 @@ namespace TContractManager {
         REQUIRE(getBalanceDestinationDecoder.getData<uint256_t>(0) == 500000000000000000);
       }
 
-      std::unique_ptr options = std::make_unique<Options>(Options::fromFile("ContractManagerTestCreateNew"));
-      std::unique_ptr db = std::make_unique<DB>("ContractManagerTestCreateNew");
+      std::unique_ptr options = std::make_unique<Options>(Options::fromFile(testDumpPath + "/ContractManagerTestCreateNew"));
+      std::unique_ptr db = std::make_unique<DB>(testDumpPath + "/ContractManagerTestCreateNew");
       std::unique_ptr<rdPoS> rdpos;
       ContractManager contractManager(nullptr, db, rdpos, options);
 

--- a/tests/contract/contractmanager.cpp
+++ b/tests/contract/contractmanager.cpp
@@ -152,7 +152,7 @@ namespace TContractManager {
 
         ABI::Encoder::EncVar transferVars;
         transferVars.push_back(destinationOfTransfer);
-        transferVars.push_back(500000000000000000);
+        transferVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder transferEncoder(transferVars);
         Bytes transferData = Hex::toBytes("0xa9059cbb");
         Utils::appendBytes(transferData, transferEncoder.getData());

--- a/tests/contract/dexv2.cpp
+++ b/tests/contract/dexv2.cpp
@@ -72,13 +72,13 @@ Address createNewERC20(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& rd
   auto createNewERC20Tx = createNewTransaction(
     chainOwnerPrivKey,
     ProtocolContractAddresses.at("ContractManager"),
-    0,
+    uint256_t(0),
     state,
     options,
     Hex::toBytes("0xb74e5ed5"),
     tokenName,
     tokenSymbol,
-    decimals,
+    static_cast<uint256_t>(decimals),
     mintValue
   );
   auto prevContractList = state->getContracts();
@@ -113,7 +113,7 @@ Address createNewFactory(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& 
   auto createNewFactoryTx = createNewTransaction(
     chainOwnerPrivKey,
     ProtocolContractAddresses.at("ContractManager"),
-    0,
+    uint256_t(0),
     state,
     options,
     Hex::toBytes("0xf02da5d2"),
@@ -153,7 +153,7 @@ Address createNewRouter(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& r
   auto createNewRouterTx = createNewTransaction(
     chainOwnerPrivKey,
     ProtocolContractAddresses.at("ContractManager"),
-    0,
+    uint256_t(0),
     state,
     options,
     Hex::toBytes("0x5d0ba0d6"),
@@ -193,13 +193,13 @@ Address createNewNative(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& r
   auto createNewNativeTx = createNewTransaction(
     chainOwnerPrivKey,
     ProtocolContractAddresses.at("ContractManager"),
-    0,
+    uint256_t(0),
     state,
     options,
     Hex::toBytes("0xb296fad4"),
     tokenName,
     tokenSymbol,
-    tokenDecimal
+    static_cast<uint256_t>(tokenDecimal)
   );
 
   auto prevContractList = state->getContracts();
@@ -232,7 +232,7 @@ TxBlock createApproveTx(std::unique_ptr<State>& state, std::unique_ptr<Options>&
   auto approveTx = createNewTransaction(
     privKey,
     erc20,
-    0,
+    uint256_t(0),
     state,
     options,
     Hex::toBytes("0x095ea7b3"),
@@ -371,7 +371,7 @@ namespace TDEXV2 {
         auto addLiquidityTx = createNewTransaction(
           ownerPrivKey,
           router,
-          0,
+          uint256_t(0),
           state,
           options,
           Hex::toBytes("0xe8e33700"),
@@ -379,8 +379,8 @@ namespace TDEXV2 {
           tokenB,                                                       // tokenB
           uint256_t("100000000000000000000"),                           // amountADesired
           uint256_t("250000000000000000000"),                           // amountBDesired
-          0,                                                            // amountAMin
-          0,                                                            // amountBMin
+          uint256_t(0),                                                            // amountAMin
+          uint256_t(0),                                                          // amountBMin
           Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),        // to
           unixtimestamp                                                 // deadline
         );

--- a/tests/contract/dexv2.cpp
+++ b/tests/contract/dexv2.cpp
@@ -243,6 +243,7 @@ TxBlock createApproveTx(std::unique_ptr<State>& state, std::unique_ptr<Options>&
 }
 
 namespace TDEXV2 {
+  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("DEXV2 Test", "[contract][dexv2]") {
 
     SECTION("Deploy DEXV2Router/Factory") {
@@ -258,7 +259,7 @@ namespace TDEXV2 {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "DEXV2NewContractsTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/DEXV2NewContractsTest");
         wrapped = createNewNative(
           state, rdpos, storage, options,
           "WSPARQ", "WSPARQ", 18
@@ -281,7 +282,7 @@ namespace TDEXV2 {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, "DEXV2NewContractsTest");
+      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/DEXV2NewContractsTest");
 
       auto contracts = state->getContracts();
 
@@ -313,7 +314,7 @@ namespace TDEXV2 {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "DEXV2NewContractsTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/DEXV2NewContractsTest");
 
         std::cout << "Creating native contract" << std::endl;
 

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -68,6 +68,7 @@ void initialize(std::unique_ptr<Options>& options,
 }
 
 namespace TERC20 {
+  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("ERC2O Class", "[contract][erc20]") {
     PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
     Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
@@ -77,7 +78,7 @@ namespace TERC20 {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20ClassConstructor";
+        std::string dbName = testDumpPath + "/erc20ClassConstructor";
         std::string tokenName = "TestToken";
         std::string tokenSymbol = "TST";
         uint8_t tokenDecimals = 18;
@@ -117,7 +118,7 @@ namespace TERC20 {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20ClassConstructor";
+      std::string dbName = testDumpPath + "/erc20ClassConstructor";
       std::string tokenName = "TestToken";
       std::string tokenSymbol = "TST";
       uint8_t tokenDecimals = 18;
@@ -162,7 +163,7 @@ namespace TERC20 {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20ClassTransfer";
+        std::string dbName = testDumpPath + "/erc20ClassTransfer";
         std::string tokenName = "TestToken";
         std::string tokenSymbol = "TST";
         uint8_t tokenDecimals = 18;
@@ -239,7 +240,7 @@ namespace TERC20 {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20ClassTransfer";
+      std::string dbName = testDumpPath + "/erc20ClassTransfer";
       std::string tokenName = "TestToken";
       std::string tokenSymbol = "TST";
       uint8_t tokenDecimals = 18;
@@ -274,7 +275,7 @@ namespace TERC20 {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20ClassApprove";
+        std::string dbName = testDumpPath + "/erc20ClassApprove";
         std::string tokenName = "TestToken";
         std::string tokenSymbol = "TST";
         uint8_t tokenDecimals = 18;
@@ -324,7 +325,7 @@ namespace TERC20 {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20ClassApprove";
+      std::string dbName = testDumpPath + "/erc20ClassApprove";
       std::string tokenName = "TestToken";
       std::string tokenSymbol = "TST";
       uint8_t tokenDecimals = 18;
@@ -352,7 +353,7 @@ namespace TERC20 {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20ClassTransferFrom";
+        std::string dbName = testDumpPath + "/erc20ClassTransferFrom";
         std::string tokenName = "TestToken";
         std::string tokenSymbol = "TST";
         uint8_t tokenDecimals = 18;
@@ -460,7 +461,7 @@ namespace TERC20 {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20ClassTransferFrom";
+      std::string dbName = testDumpPath + "/erc20ClassTransferFrom";
       std::string tokenName = "TestToken";
       std::string tokenSymbol = "TST";
       uint8_t tokenDecimals = 18;

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -44,7 +44,7 @@ void initialize(std::unique_ptr<Options>& options,
     ABI::Encoder::EncVar createNewERC20ContractVars;
     createNewERC20ContractVars.push_back(tokenName);
     createNewERC20ContractVars.push_back(tokenSymbol);
-    createNewERC20ContractVars.push_back(tokenDecimals);
+    createNewERC20ContractVars.push_back(static_cast<uint256_t>(tokenDecimals));
     createNewERC20ContractVars.push_back(tokenSupply);
     ABI::Encoder createNewERC20ContractEncoder(createNewERC20ContractVars);
     Bytes createNewERC20ContractData = Hex::toBytes("0xb74e5ed5");
@@ -183,7 +183,7 @@ namespace TERC20 {
 
         ABI::Encoder::EncVar transferVars;
         transferVars.push_back(destinationOfTransactions);
-        transferVars.push_back(500000000000000000);
+        transferVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder transferEncoder(transferVars);
         Bytes transferData = Hex::toBytes("0xa9059cbb");
         Utils::appendBytes(transferData, transferEncoder.getData());
@@ -291,7 +291,7 @@ namespace TERC20 {
 
         ABI::Encoder::EncVar approveVars;
         approveVars.push_back(destinationOfApproval);
-        approveVars.push_back(500000000000000000);
+        approveVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder approveEncoder(approveVars);
         Bytes approveData = Hex::toBytes("0x095ea7b3");
         Utils::appendBytes(approveData, approveEncoder.getData());
@@ -364,7 +364,7 @@ namespace TERC20 {
         erc20Address = contractManager->getContracts()[0].second;
         ABI::Encoder::EncVar approveVars;
         approveVars.push_back(destinationOfApproval);
-        approveVars.push_back(500000000000000000);
+        approveVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder approveEncoder(approveVars);
         Bytes approveData = Hex::toBytes("0x095ea7b3");
         Utils::appendBytes(approveData, approveEncoder.getData());
@@ -386,7 +386,7 @@ namespace TERC20 {
         ABI::Encoder::EncVar transferFromVars;
         transferFromVars.push_back(owner);
         transferFromVars.push_back(destinationOfApproval);
-        transferFromVars.push_back(500000000000000000);
+        transferFromVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder transferFromEncoder(transferFromVars);
         Bytes transferFromBytes = Hex::toBytes("0x23b872dd");
         Utils::appendBytes(transferFromBytes, transferFromEncoder.getData());

--- a/tests/contract/erc20wrapper.cpp
+++ b/tests/contract/erc20wrapper.cpp
@@ -72,6 +72,7 @@ void initialize(std::unique_ptr<Options>& options,
 }
 
 namespace TERC20Wrapper {
+  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("ERC20Wrapper Class", "[contract][erc20wrapper]") {
     PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
     Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
@@ -82,7 +83,7 @@ namespace TERC20Wrapper {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20wrapperDb";
+        std::string dbName = testDumpPath + "/erc20wrapperDb";
         initialize(options, db, contractManager, dbName, ownerPrivKey);
         for (const auto& [name, address] : contractManager->getContracts()) {
           if (name == "ERC20") {
@@ -96,7 +97,7 @@ namespace TERC20Wrapper {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20wrapperDb";
+      std::string dbName = testDumpPath + "/erc20wrapperDb";
       initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
       for (const auto& [name, address] : contractManager->getContracts()) {
@@ -116,7 +117,7 @@ namespace TERC20Wrapper {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20wrapperDb";
+        std::string dbName = testDumpPath + "/erc20wrapperDb";
         initialize(options, db, contractManager, dbName, ownerPrivKey);
         for (const auto &[name, address]: contractManager->getContracts()) {
           if (name == "ERC20") {
@@ -215,7 +216,7 @@ namespace TERC20Wrapper {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20wrapperDb";
+      std::string dbName = testDumpPath + "/erc20wrapperDb";
       initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
       ABI::Encoder::EncVar getAllowanceVars;
@@ -255,7 +256,7 @@ namespace TERC20Wrapper {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20wrapperDb";
+        std::string dbName = testDumpPath + "/erc20wrapperDb";
         initialize(options, db, contractManager, dbName, ownerPrivKey);
         for (const auto &[name, address]: contractManager->getContracts()) {
           if (name == "ERC20") {
@@ -393,7 +394,7 @@ namespace TERC20Wrapper {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20wrapperDb";
+      std::string dbName = testDumpPath + "/erc20wrapperDb";
       initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
       ABI::Encoder::EncVar getAllowanceVars;
@@ -434,7 +435,7 @@ namespace TERC20Wrapper {
         std::unique_ptr<Options> options;
         std::unique_ptr<DB> db;
         std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = "erc20wrapperDb";
+        std::string dbName = testDumpPath + "/erc20wrapperDb";
         initialize(options, db, contractManager, dbName, ownerPrivKey);
         for (const auto &[name, address]: contractManager->getContracts()) {
           if (name == "ERC20") {
@@ -579,7 +580,7 @@ namespace TERC20Wrapper {
       std::unique_ptr<Options> options;
       std::unique_ptr<DB> db;
       std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = "erc20wrapperDb";
+      std::string dbName = testDumpPath + "/erc20wrapperDb";
       initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
       ABI::Encoder::EncVar getAllowanceVars;

--- a/tests/contract/erc20wrapper.cpp
+++ b/tests/contract/erc20wrapper.cpp
@@ -33,8 +33,8 @@ void initialize(std::unique_ptr<Options>& options,
     ABI::Encoder::EncVar createNewERC20ContractVars;
     createNewERC20ContractVars.push_back("TestToken");
     createNewERC20ContractVars.push_back("TST");
-    createNewERC20ContractVars.push_back(18);
-    createNewERC20ContractVars.push_back(1000000000000000000);
+    createNewERC20ContractVars.push_back(static_cast<uint256_t>(18));
+    createNewERC20ContractVars.push_back(static_cast<uint256_t>(1000000000000000000));
     ABI::Encoder createNewERC20ContractEncoder(createNewERC20ContractVars);
     Bytes createNewERC20ContractData = Hex::toBytes("0xb74e5ed5");
     Utils::appendBytes(createNewERC20ContractData, createNewERC20ContractEncoder.getData());
@@ -135,7 +135,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar depositVars;
         depositVars.push_back(erc20Address);
-        depositVars.push_back(500000000000000000);
+        depositVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder depositEncoder(depositVars);
         Bytes depositData = Hex::toBytes("0x47e7ef24");
         Utils::appendBytes(depositData, depositEncoder.getData());
@@ -157,7 +157,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar approveVars;
         approveVars.push_back(wrapperAddress);
-        approveVars.push_back(500000000000000000);
+        approveVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder approveEncoder(approveVars);
         Bytes approveData = Hex::toBytes("0x095ea7b3");
         Utils::appendBytes(approveData, approveEncoder.getData());
@@ -274,7 +274,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar depositVars;
         depositVars.push_back(erc20Address);
-        depositVars.push_back(500000000000000000);
+        depositVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder depositEncoder(depositVars);
         Bytes depositData = Hex::toBytes("0x47e7ef24");
         Utils::appendBytes(depositData, depositEncoder.getData());
@@ -295,7 +295,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar approveVars;
         approveVars.push_back(wrapperAddress);
-        approveVars.push_back(500000000000000000);
+        approveVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder approveEncoder(approveVars);
         Bytes approveData = Hex::toBytes("0x095ea7b3");
         Utils::appendBytes(approveData, approveEncoder.getData());
@@ -352,7 +352,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar withdrawVars;
         withdrawVars.push_back(erc20Address);
-        withdrawVars.push_back(250000000000000000);
+        withdrawVars.push_back(static_cast<uint256_t>(250000000000000000));
         ABI::Encoder withdrawEncoder(withdrawVars);
         Bytes withdrawData = Hex::toBytes("0xf3fef3a3");
         Utils::appendBytes(withdrawData, withdrawEncoder.getData());
@@ -453,7 +453,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar depositVars;
         depositVars.push_back(erc20Address);
-        depositVars.push_back(500000000000000000);
+        depositVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder depositEncoder(depositVars);
         Bytes depositData = Hex::toBytes("0x47e7ef24");
         Utils::appendBytes(depositData, depositEncoder.getData());
@@ -474,7 +474,7 @@ namespace TERC20Wrapper {
 
         ABI::Encoder::EncVar approveVars;
         approveVars.push_back(wrapperAddress);
-        approveVars.push_back(500000000000000000);
+        approveVars.push_back(static_cast<uint256_t>(500000000000000000));
         ABI::Encoder approveEncoder(approveVars);
         Bytes approveData = Hex::toBytes("0x095ea7b3");
         Utils::appendBytes(approveData, approveEncoder.getData());
@@ -532,7 +532,7 @@ namespace TERC20Wrapper {
         ABI::Encoder::EncVar transferToVars;
         transferToVars.push_back(erc20Address);
         transferToVars.push_back(destinationOfTransfers);
-        transferToVars.push_back(250000000000000000);
+        transferToVars.push_back(static_cast<uint256_t>(250000000000000000));
         ABI::Encoder transferToEncoder(transferToVars);
         Bytes transferToData = Hex::toBytes("0xa5f2a152");
         Utils::appendBytes(transferToData, transferToEncoder.getData());

--- a/tests/contract/nativewrapper.cpp
+++ b/tests/contract/nativewrapper.cpp
@@ -37,6 +37,7 @@ const std::vector<Hash> validatorPrivKeys {
 
 namespace TNativeWrapper {
   TEST_CASE("NativeWrapper tests", "[contract][nativewrapper]") {
+    std::string testDumpPath = Utils::getTestDumpPath();
     SECTION("NativeWrapper Constructor") {
       PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
       Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
@@ -52,7 +53,7 @@ namespace TNativeWrapper {
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
         initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                   "NativeWrapperNewContractTest");
+                    testDumpPath + "/NativeWrapperNewContractTest");
 
         // Create a new Contract
         ABI::Encoder::EncVar createNewNativeWrapperContractVars;
@@ -109,7 +110,7 @@ namespace TNativeWrapper {
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
       initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                 "NativeWrapperNewContractTest");
+                  testDumpPath + "/NativeWrapperNewContractTest");
 
       REQUIRE(contractAddress == state->getContracts()[0].second);
       ABI::Encoder nameEncoder({}, "name()");
@@ -152,7 +153,7 @@ namespace TNativeWrapper {
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
         initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                   "NativeWrapperDepositTest");
+                   testDumpPath + "/NativeWrapperDepositTest");
 
         // Create a new Contract
         ABI::Encoder::EncVar createNewNativeWrapperContractVars;
@@ -214,7 +215,7 @@ namespace TNativeWrapper {
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
       initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                 "NativeWrapperDepositTest");
+                  testDumpPath + "/NativeWrapperDepositTest");
 
       REQUIRE(contractAddress == state->getContracts()[0].second);
       REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer);
@@ -244,7 +245,7 @@ namespace TNativeWrapper {
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
         initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                   "NativeWrapperWithdrawTest");
+                    testDumpPath + "/NativeWrapperWithdrawTest");
 
         // Create a new Contract
         ABI::Encoder::EncVar createNewNativeWrapperContractVars;
@@ -336,7 +337,7 @@ namespace TNativeWrapper {
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
       initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                 "NativeWrapperWithdrawTest");
+                  testDumpPath + "/NativeWrapperWithdrawTest");
 
       REQUIRE(contractAddress == state->getContracts()[0].second);
       REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer - amountToWithdraw);

--- a/tests/contract/variables/safeint_t_boost.cpp
+++ b/tests/contract/variables/safeint_t_boost.cpp
@@ -1,0 +1,750 @@
+#include "../../src/libs/catch2/catch_amalgamated.hpp"
+#include "../../src/contract/variables/safeint.h"
+#include "../../src/utils/utils.h"
+#include <iostream>
+
+// Helper to map the number of bits to the corresponding type.
+template<int Size>
+struct IntType;
+
+template<> struct IntType<24> { using type = int24_t; };
+template<> struct IntType<40> { using type = int40_t; };
+template<> struct IntType<48> { using type = int48_t; };
+template<> struct IntType<56> { using type = int56_t; };
+template<> struct IntType<72> { using type = int72_t; };
+template<> struct IntType<80> { using type = int80_t; };
+template<> struct IntType<88> { using type = int88_t; };
+template<> struct IntType<96> { using type = int96_t; };
+template<> struct IntType<104> { using type = int104_t; };
+template<> struct IntType<112> { using type = int112_t; };
+template<> struct IntType<120> { using type = int120_t; };
+template<> struct IntType<128> { using type = int128_t; };
+template<> struct IntType<136> { using type = int136_t; };
+template<> struct IntType<144> { using type = int144_t; };
+template<> struct IntType<152> { using type = int152_t; };
+template<> struct IntType<160> { using type = int160_t; };
+template<> struct IntType<168> { using type = int168_t; };
+template<> struct IntType<176> { using type = int176_t; };
+template<> struct IntType<184> { using type = int184_t; };
+template<> struct IntType<192> { using type = int192_t; };
+template<> struct IntType<200> { using type = int200_t; };
+template<> struct IntType<208> { using type = int208_t; };
+template<> struct IntType<216> { using type = int216_t; };
+template<> struct IntType<224> { using type = int224_t; };
+template<> struct IntType<232> { using type = int232_t; };
+template<> struct IntType<240> { using type = int240_t; };
+template<> struct IntType<248> { using type = int248_t; };
+template<> struct IntType<256> { using type = int256_t; };
+
+template <int Size>
+struct SafeIntTester {
+    using SafeInt = SafeInt_t<Size>;
+    using UnderlyingType = typename IntType<Size>::type;
+
+    void operator()() const {
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> constructor (Commit and Revert") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            SafeInt revertedValue(UnderlyingType(-356897));
+
+            commitedValue.commit();
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-356897));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator+") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue + 2257;
+            revertedValue = revertedValue + 2257;
+
+            try {
+                throwValueOverflow = throwValueOverflow + 1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+            try {
+                throwValueUnderflow = throwValueUnderflow - 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-354640));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator-") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue - 2257;
+            revertedValue = revertedValue - 2257;
+
+            try {
+                throwValueOverflow = throwValueOverflow + 1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+            try {
+                throwValueUnderflow = throwValueUnderflow - 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-359154));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator*") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue * 2;
+            revertedValue = revertedValue * 2;
+
+            try {
+                throwValueOverflow = throwValueOverflow * 2;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+            try {
+                throwValueUnderflow = throwValueUnderflow * 2;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-713794));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator/") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueOverflow.commit();
+
+            bool overflow = false;
+            bool domain_error = false;
+
+            commitedValue = commitedValue / 2;
+            revertedValue = revertedValue / 2;
+
+            try {
+                throwValueOverflow = throwValueOverflow / UnderlyingType(0);
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+            try {
+                throwValueOverflow = throwValueOverflow / -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-178448));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator%") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+
+            bool domain_error = false;
+
+            commitedValue = commitedValue % 2;
+            revertedValue = revertedValue % 2;
+
+            try {
+                commitedValue = commitedValue % UnderlyingType(0);
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-1));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue & 0x0000FFFF;
+            revertedValue = revertedValue & 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(29217));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator|") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue | 0x0000FFFF;
+            revertedValue = revertedValue | 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(393215));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator^") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue ^ 0x0000FFFF;
+            revertedValue = revertedValue ^ 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(363998));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator!") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = !commitedValue;
+            revertedValue = !revertedValue;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&&") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue && 0x0000FFFF;
+            revertedValue = revertedValue && 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator||") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue || 0x0000FFFF;
+            revertedValue = revertedValue || 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator==") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue == 0x0000FFFF;
+            revertedValue = revertedValue == 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator!=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue != 0x0000FFFF;
+            revertedValue = revertedValue != 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue > 0x0000FFFF;
+            revertedValue = revertedValue > 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue = commitedValue < 0x0000FFFF;
+            revertedValue = revertedValue < 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+            SafeInt commitedValue2(UnderlyingType(0x0000FFFF));
+            commitedValue2.commit();
+            SafeInt revertedValue2(UnderlyingType(0x0000FFFF));
+            revertedValue2.commit();
+
+            commitedValue = commitedValue >= commitedValue2;
+            revertedValue = revertedValue >= revertedValue2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+            SafeInt commitedValue2(UnderlyingType(0x0000FFFF));
+            commitedValue2.commit();
+            SafeInt revertedValue2(UnderlyingType(0x0000FFFF));
+            revertedValue2.commit();
+
+            commitedValue = commitedValue <= commitedValue2;
+            revertedValue = revertedValue <= revertedValue2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = 0x0000FFFF;
+            revertedValue = 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(65535));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator+=") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue += 2257;
+            revertedValue += 2257;
+
+            try {
+                throwValueOverflow += 1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow += -1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-354640));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator-=") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue -= 2257;
+            revertedValue -= 2257;
+
+            try {
+                throwValueOverflow -= -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow -= 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-359154));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator*=") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue *= 2;
+            revertedValue *= 2;
+
+            try {
+                throwValueOverflow *= 2;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow *= 2;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-713794));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator/=") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueOverflow.commit();
+
+            bool overflow = false;
+            bool domain_error = false;
+
+            commitedValue /= 2;
+            revertedValue /= 2;
+
+            try {
+                throwValueOverflow /= UnderlyingType(0);
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            try {
+                throwValueOverflow /= -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-178448));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(overflow);
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator%=") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            revertedValue.commit();
+
+            bool domain_error = false;
+
+            commitedValue %= 2;
+            revertedValue %= 2;
+
+            try {
+                commitedValue %= UnderlyingType(0);
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-1));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue &= 0x0000FFFF;
+            revertedValue &= 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(29217));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator|=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue |= 0x0000FFFF;
+            revertedValue |= 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(393215));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator^=") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+
+            commitedValue ^= 0x0000FFFF;
+            revertedValue ^= 0x0000FFFF;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(363998));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator++") {
+            SafeInt commitedValue(UnderlyingType(356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(356897));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+
+            bool overflow = false;
+
+            ++commitedValue;
+            ++revertedValue;
+
+            try {
+                ++throwValueOverflow;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(356898));
+            REQUIRE(revertedValue.get() == UnderlyingType(356897));
+            REQUIRE(overflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator--") {
+            SafeInt commitedValue(UnderlyingType(-356897));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-356897));
+            revertedValue.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool underflow = false;
+
+            --commitedValue;
+            --revertedValue;
+
+            try {
+                --throwValueUnderflow;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-356898));
+            REQUIRE(revertedValue.get() == UnderlyingType(-356897));
+            REQUIRE(underflow);
+        }
+    }
+};
+
+TEST_CASE("SafeInt_t tests", "[contract][variables][safeint_t_boost]") {
+    SafeIntTester<24>()();
+    SafeIntTester<40>()();
+    SafeIntTester<48>()();
+    SafeIntTester<56>()();
+    SafeIntTester<72>()();
+    SafeIntTester<80>()();
+    SafeIntTester<88>()();
+    SafeIntTester<96>()();
+    SafeIntTester<104>()();
+    SafeIntTester<112>()();
+    SafeIntTester<120>()();
+    SafeIntTester<128>()();
+    SafeIntTester<136>()();
+    SafeIntTester<144>()();
+    SafeIntTester<152>()();
+    SafeIntTester<160>()();
+    SafeIntTester<168>()();
+    SafeIntTester<176>()();
+    SafeIntTester<184>()();
+    SafeIntTester<192>()();
+    SafeIntTester<200>()();
+    SafeIntTester<208>()();
+    SafeIntTester<216>()();
+    SafeIntTester<224>()();
+    SafeIntTester<232>()();
+    SafeIntTester<240>()();
+    SafeIntTester<248>()();
+    SafeIntTester<256>()();
+}

--- a/tests/contract/variables/safeint_t_c++.cpp
+++ b/tests/contract/variables/safeint_t_c++.cpp
@@ -1,0 +1,768 @@
+#include "../../src/libs/catch2/catch_amalgamated.hpp"
+#include "../../src/contract/variables/safeint.h"
+#include <iostream>
+#include <stdexcept>
+
+template <int Size>
+struct UnderlyingType;
+
+template <>
+struct UnderlyingType<8> { using type = int8_t; };
+
+template <>
+struct UnderlyingType<16> { using type = int16_t; };
+
+template <>
+struct UnderlyingType<32> { using type = int32_t; };
+
+template <>
+struct UnderlyingType<64> { using type = int64_t; };
+
+template <int Size>
+struct SafeIntTester {
+    using SafeInt = SafeInt_t<Size>;
+    using UnderlyingType = typename UnderlyingType<Size>::type;
+
+    void operator()() const {
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> constructor (Commit and Revert") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            SafeInt revertedValue(UnderlyingType(-42));
+
+            commitedValue.commit();
+            REQUIRE(commitedValue.get() == UnderlyingType(-42));
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-42));
+            REQUIRE(revertedValue.get() == 0);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator+") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue + 5;
+            revertedValue = revertedValue + 5;
+
+            try {
+                throwValueOverflow = throwValueOverflow + 1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+            try {
+                throwValueUnderflow = throwValueUnderflow - 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-37));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator-") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue - 5;
+            revertedValue = revertedValue - 5;
+
+            // To test overflow, subtract a negative number from the max value.
+            try {
+                throwValueOverflow = throwValueOverflow - (-1);
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            // To test underflow, subtract a positive number from the min value.
+            try {
+                throwValueUnderflow = throwValueUnderflow - 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-47));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator*") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue = commitedValue * 2;
+            revertedValue = revertedValue * 2;
+
+            try {
+                throwValueOverflow = throwValueOverflow * 2;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow = throwValueUnderflow * 2;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-84));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator/") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool domain_error = false;
+            bool overflow = false;
+
+            commitedValue = commitedValue / 2;
+            revertedValue = revertedValue / 2;
+
+            try {
+                throwValueUnderflow = throwValueUnderflow / 0;
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            try {
+                throwValueUnderflow = throwValueUnderflow / -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-21));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(domain_error);
+            REQUIRE(overflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator%") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            
+            bool domain_error = false;
+
+            commitedValue = commitedValue % 2;
+            revertedValue = revertedValue % 2;
+
+            try {
+                commitedValue = commitedValue % 0;
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue = commitedValue & UnderlyingType(0b11110000);
+            revertedValue = revertedValue & UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b10100000));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator|") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue = commitedValue | UnderlyingType(0b11110000);
+            revertedValue = revertedValue | UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b11111010));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator^") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue = commitedValue ^ UnderlyingType(0b11110000);
+            revertedValue = revertedValue ^ UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b01011010));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<<") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue = commitedValue << 2;
+            revertedValue = revertedValue << 2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b1010101000));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>>") {
+            SafeInt commitedValue(UnderlyingType(0b00101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b00101010));
+            revertedValue.commit();
+
+            commitedValue = commitedValue >> 2;
+            revertedValue = revertedValue >> 2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b00001010)); 
+            REQUIRE(revertedValue.get() == UnderlyingType(0b00101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator!") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = !commitedValue;
+            revertedValue = !revertedValue;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&&") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = commitedValue && SafeInt(UnderlyingType(1));
+            revertedValue = revertedValue && SafeInt(UnderlyingType(1));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator||") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = commitedValue || SafeInt(UnderlyingType(1));
+            revertedValue = revertedValue || SafeInt(UnderlyingType(1));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator==") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = commitedValue == SafeInt(UnderlyingType(1));
+            revertedValue = revertedValue == SafeInt(UnderlyingType(1));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator!=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = commitedValue != SafeInt(UnderlyingType(1));
+            revertedValue = revertedValue != SafeInt(UnderlyingType(1));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+
+            commitedValue = commitedValue < SafeInt(UnderlyingType(-41));
+            revertedValue = revertedValue < SafeInt(UnderlyingType(-41));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+
+            commitedValue = commitedValue > SafeInt(UnderlyingType(-41));
+            revertedValue = revertedValue > SafeInt(UnderlyingType(-41));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>=") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+
+            commitedValue = commitedValue >= SafeInt(UnderlyingType(-41));
+            revertedValue = revertedValue >= SafeInt(UnderlyingType(-41));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<=") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+
+            commitedValue = commitedValue <= SafeInt(UnderlyingType(-41));
+            revertedValue = revertedValue <= SafeInt(UnderlyingType(-41));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+
+            commitedValue = SafeInt(UnderlyingType(1));
+            revertedValue = SafeInt(UnderlyingType(1));
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(1));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator+=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue += 5;
+            revertedValue += 5;
+
+            try {
+                throwValueOverflow += 1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow += -1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(5));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator-=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue -= 5;
+            revertedValue -= 5;
+
+            try {
+                throwValueOverflow -= -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow -= 1;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-5));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator*=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool overflow = false;
+            bool underflow = false;
+
+            commitedValue *= 2;
+            revertedValue *= 2;
+
+            try {
+                throwValueOverflow *= 2;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            try {
+                throwValueUnderflow *= 2;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+            REQUIRE(overflow);
+            REQUIRE(underflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator/=") {
+            SafeInt commitedValue(UnderlyingType(0));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0));
+            revertedValue.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool domain_error = false;
+            bool overflow = false;
+
+            commitedValue /= 2;
+            revertedValue /= 2;
+
+            try {
+                throwValueUnderflow /= 0;
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            try {
+                throwValueUnderflow /= -1;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(0));
+            REQUIRE(domain_error);
+            REQUIRE(overflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator%=") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool domain_error = false;
+
+            commitedValue %= 2;
+            revertedValue %= 2;
+
+            try {
+                throwValueUnderflow %= 0;
+            } catch (std::domain_error &e) {
+                domain_error = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(domain_error);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator&=") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue &= UnderlyingType(0b11110000);
+            revertedValue &= UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b10100000));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator|=") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue |= UnderlyingType(0b11110000);
+            revertedValue |= UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b11111010));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator^=") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue ^= UnderlyingType(0b11110000);
+            revertedValue ^= UnderlyingType(0b11110000);
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b01011010));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator<<=") {
+            SafeInt commitedValue(UnderlyingType(0b10101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b10101010));
+            revertedValue.commit();
+
+            commitedValue <<= 2;
+            revertedValue <<= 2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b1010101000));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b10101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator>>=") {
+            SafeInt commitedValue(UnderlyingType(0b00101010));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(0b00101010));
+            revertedValue.commit();
+
+            commitedValue >>= 2;
+            revertedValue >>= 2;
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(0b00001010));
+            REQUIRE(revertedValue.get() == UnderlyingType(0b00101010));
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator++") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueOverflow(std::numeric_limits<UnderlyingType>::max());
+            throwValueOverflow.commit();
+
+            bool overflow = false;
+
+            ++commitedValue;
+            ++revertedValue;
+
+            try {
+                ++throwValueOverflow;
+            } catch (std::overflow_error &e) {
+                overflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-41));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(overflow);
+        }
+
+        SECTION(std::string("SafeInt_t<") + std::to_string(Size) + "> operator--") {
+            SafeInt commitedValue(UnderlyingType(-42));
+            commitedValue.commit();
+            SafeInt revertedValue(UnderlyingType(-42));
+            revertedValue.commit();
+            SafeInt throwValueUnderflow(std::numeric_limits<UnderlyingType>::min());
+            throwValueUnderflow.commit();
+
+            bool underflow = false;
+
+            --commitedValue;
+            --revertedValue;
+
+            try {
+                --throwValueUnderflow;
+            } catch (std::underflow_error &e) {
+                underflow = true;
+            }
+
+            commitedValue.commit();
+            revertedValue.revert();
+
+            REQUIRE(commitedValue.get() == UnderlyingType(-43));
+            REQUIRE(revertedValue.get() == UnderlyingType(-42));
+            REQUIRE(underflow);
+        }
+
+
+    }
+};
+
+TEST_CASE("SafeInt_t tests", "[contract][variables][safeint_t]") {
+    SafeIntTester<8>()();
+    SafeIntTester<16>()();
+    SafeIntTester<32>()();
+    SafeIntTester<64>()();
+}

--- a/tests/core/blockchain.cpp
+++ b/tests/core/blockchain.cpp
@@ -49,13 +49,14 @@ void initialize(const std::string& blockchainPath,
 
 namespace TBlockchain {
   TEST_CASE("Blockchain Class", "[core][blockchain]") {
+    std::string testDumpPath = Utils::getTestDumpPath();
     SECTION("Initialize Blockchain Multiple Nodes") {
       std::shared_ptr<const Block> bestBlock;
       {
         /// Initialize ManagerDiscovery
         std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
         std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-            "statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
+            testDumpPath + "/statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
             "OrbiterSDK/cpp/linux_x86-64/0.1.2",
             1,
             8080,
@@ -144,7 +145,7 @@ namespace TBlockchain {
       {
         std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
         std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-            "statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
+            testDumpPath + "/statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
             "OrbiterSDK/cpp/linux_x86-64/0.1.2",
             1,
             8080,

--- a/tests/core/rdpos.cpp
+++ b/tests/core/rdpos.cpp
@@ -184,6 +184,7 @@ Block createValidBlock(std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& 
 namespace TRdPoS {
   // Simple rdPoS execution, does not test network functionality neither validator execution (rdPoSWorker)
   TEST_CASE("rdPoS Class", "[core][rdpos]") {
+    std::string testDumpPath = Utils::getTestDumpPath();
     SECTION("rdPoS class Startup") {
       std::set<Validator> validatorsList;
       {
@@ -194,7 +195,7 @@ namespace TRdPoS {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<Options> options;
         std::unique_ptr<State> state;
-        initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, "rdPoSStartup");
+        initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, testDumpPath + "/rdPoSStartup");
 
         auto validators = rdpos->getValidators();
         REQUIRE(rdpos->getValidators().size() == 8);
@@ -233,7 +234,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<Options> options;
       std::unique_ptr<State> state;
-      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, false, "rdPoSStartup");
+      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, false, testDumpPath + "/rdPoSStartup");
 
       auto validators = rdpos->getValidators();
       REQUIRE(validators == validatorsList);
@@ -247,7 +248,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<Options> options;
       std::unique_ptr<State> state;
-      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, "rdPoSValidateBlock");
+      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, testDumpPath + "/rdPoSValidateBlockOneBlock");
 
       auto block = createValidBlock(rdpos, storage);
       // Validate the block on rdPoS
@@ -265,7 +266,7 @@ namespace TRdPoS {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<Options> options;
         std::unique_ptr<State> state;
-        initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, "rdPoSValidateBlockTenBlocks");
+        initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, true, testDumpPath + "/rdPoSValidateBlockTenBlocks");
 
         for (uint64_t i = 0; i < 10; ++i) {
           // Create a valid block, with the correct rdPoS transactions
@@ -298,7 +299,7 @@ namespace TRdPoS {
       std::unique_ptr<Options> options;
       std::unique_ptr<State> state;
       // Initialize same DB and storage as before.
-      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, false, "rdPoSValidateBlockTenBlocks");
+      initialize(db, storage, p2p, validatorKey, rdpos, options, state, 8080, false, testDumpPath + "/rdPoSValidateBlockTenBlocks");
 
       REQUIRE(rdpos->getBestRandomSeed() == expectedRandomnessFromBestBlock);
       REQUIRE(rdpos->getRandomList() == expectedRandomList);
@@ -308,6 +309,7 @@ namespace TRdPoS {
   TEST_CASE("rdPoS Class With Network Functionality", "[core][rdpos][net]") {
     SECTION("Two Nodes instances, simple transaction broadcast") {
       // Initialize two different node instances, with different ports and DBs.
+      std::string testDumpPath = Utils::getTestDumpPath();
       std::unique_ptr<DB> db1;
       std::unique_ptr<Storage> storage1;
       std::unique_ptr<P2P::ManagerNormal> p2p1;
@@ -315,7 +317,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos1;
       std::unique_ptr<Options> options1;
       std::unique_ptr<State> state1;
-      initialize(db1, storage1, p2p1, validatorKey1, rdpos1, options1, state1, 8080, true, "rdPosBasicNetworkNode1");
+      initialize(db1, storage1, p2p1, validatorKey1, rdpos1, options1, state1, 8080, true, testDumpPath + "/rdPosBasicNetworkNode1");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -324,7 +326,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos2;
       std::unique_ptr<Options> options2;
       std::unique_ptr<State> state2;
-      initialize(db2, storage2, p2p2, validatorKey2, rdpos2, options2, state2, 8081, true, "rdPosBasicNetworkNode2");
+      initialize(db2, storage2, p2p2, validatorKey2, rdpos2, options2, state2, 8081, true, testDumpPath + "/rdPosBasicNetworkNode2");
 
 
       // Start respective p2p servers, and connect each other.
@@ -428,6 +430,7 @@ namespace TRdPoS {
 
     SECTION("Ten NormalNodes and one DiscoveryNode, test broadcast") {
       // Initialize ten different node instances, with different ports and DBs.
+      std::string testDumpPath = Utils::getTestDumpPath();
       std::unique_ptr<DB> db1;
       std::unique_ptr<Storage> storage1;
       std::unique_ptr<P2P::ManagerNormal> p2p1;
@@ -435,7 +438,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos1;
       std::unique_ptr<Options> options1;
       std::unique_ptr<State> state1;
-      initialize(db1, storage1, p2p1, validatorKey1, rdpos1, options1, state1, 8080, true, "rdPoSdiscoveryNodeTestBroadcastNode1");
+      initialize(db1, storage1, p2p1, validatorKey1, rdpos1, options1, state1, 8080, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode1");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -444,7 +447,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos2;
       std::unique_ptr<Options> options2;
       std::unique_ptr<State> state2;
-      initialize(db2, storage2, p2p2, validatorKey2, rdpos2, options2, state2, 8081, true, "rdPoSdiscoveryNodeTestBroadcastNode2");
+      initialize(db2, storage2, p2p2, validatorKey2, rdpos2, options2, state2, 8081, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode2");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -453,7 +456,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos3;
       std::unique_ptr<Options> options3;
       std::unique_ptr<State> state3;
-      initialize(db3, storage3, p2p3, validatorKey3, rdpos3, options3, state3, 8082, true, "rdPoSdiscoveryNodeTestBroadcastNode3");
+      initialize(db3, storage3, p2p3, validatorKey3, rdpos3, options3, state3, 8082, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode3");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -462,7 +465,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos4;
       std::unique_ptr<Options> options4;
       std::unique_ptr<State> state4;
-      initialize(db4, storage4, p2p4, validatorKey4, rdpos4, options4, state4, 8083, true, "rdPoSdiscoveryNodeTestBroadcastNode4");
+      initialize(db4, storage4, p2p4, validatorKey4, rdpos4, options4, state4, 8083, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode4");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -471,7 +474,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos5;
       std::unique_ptr<Options> options5;
       std::unique_ptr<State> state5;
-      initialize(db5, storage5, p2p5, validatorKey5, rdpos5, options5, state5, 8084, true, "rdPoSdiscoveryNodeTestBroadcastNode5");
+      initialize(db5, storage5, p2p5, validatorKey5, rdpos5, options5, state5, 8084, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode5");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -480,7 +483,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos6;
       std::unique_ptr<Options> options6;
       std::unique_ptr<State> state6;
-      initialize(db6, storage6, p2p6, validatorKey6, rdpos6, options6, state6, 8085, true, "rdPoSdiscoveryNodeTestBroadcastNode6");
+      initialize(db6, storage6, p2p6, validatorKey6, rdpos6, options6, state6, 8085, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode6");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -489,7 +492,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos7;
       std::unique_ptr<Options> options7;
       std::unique_ptr<State> state7;
-      initialize(db7, storage7, p2p7, validatorKey7, rdpos7, options7, state7, 8086, true, "rdPoSdiscoveryNodeTestBroadcastNode7");
+      initialize(db7, storage7, p2p7, validatorKey7, rdpos7, options7, state7, 8086, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode7");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -498,7 +501,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos8;
       std::unique_ptr<Options> options8;
       std::unique_ptr<State> state8;
-      initialize(db8, storage8, p2p8, validatorKey8, rdpos8, options8, state8, 8087, true, "rdPoSdiscoveryNodeTestBroadcastNode8");
+      initialize(db8, storage8, p2p8, validatorKey8, rdpos8, options8, state8, 8087, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode8");
 
       std::unique_ptr<DB> db9;
       std::unique_ptr<Storage> storage9;
@@ -507,7 +510,7 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos9;
       std::unique_ptr<Options> options9;
       std::unique_ptr<State> state9;
-      initialize(db9, storage9, p2p9, validatorKey9, rdpos9, options9, state9, 8088, true, "rdPoSdiscoveryNodeTestBroadcastNode9");
+      initialize(db9, storage9, p2p9, validatorKey9, rdpos9, options9, state9, 8088, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode9");
 
       std::unique_ptr<DB> db10;
       std::unique_ptr<Storage> storage10;
@@ -516,12 +519,12 @@ namespace TRdPoS {
       std::unique_ptr<rdPoS> rdpos10;
       std::unique_ptr<Options> options10;
       std::unique_ptr<State> state10;
-      initialize(db10, storage10, p2p10, validatorKey10, rdpos10, options10, state10, 8089, true, "rdPoSdiscoveryNodeTestBroadcastNode10");
+      initialize(db10, storage10, p2p10, validatorKey10, rdpos10, options10, state10, 8089, true, testDumpPath + "/rdPoSdiscoveryNodeTestBroadcastNode10");
 
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> peers;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "rdPoSdiscoveryNodeTestBroadcast",
+          testDumpPath + "/rdPoSdiscoveryNodeTestBroadcast",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,
@@ -729,6 +732,7 @@ namespace TRdPoS {
 
   TEST_CASE("rdPoS class with Network and rdPoSWorker Functionality, move 10 blocks forward", "[core][rdpos][net][heavy]") {
     // Initialize 8 different node instances, with different ports and DBs.
+    std::string testDumpPath = Utils::getTestDumpPath();
     std::unique_ptr<DB> db1;
     std::unique_ptr<Storage> storage1;
     std::unique_ptr<P2P::ManagerNormal> p2p1;
@@ -736,7 +740,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos1;
     std::unique_ptr<Options> options1;
     std::unique_ptr<State> state1;
-    initialize(db1, storage1, p2p1, validatorPrivKeys[0], rdpos1, options1, state1, 8080, true, "rdPoSdiscoveryNodeTestMove10BlocksNode1");
+    initialize(db1, storage1, p2p1, validatorPrivKeys[0], rdpos1, options1, state1, 8080, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode1");
 
     std::unique_ptr<DB> db2;
     std::unique_ptr<Storage> storage2;
@@ -745,7 +749,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos2;
     std::unique_ptr<Options> options2;
     std::unique_ptr<State> state2;
-    initialize(db2, storage2, p2p2, validatorPrivKeys[1], rdpos2, options2, state2, 8081, true, "rdPoSdiscoveryNodeTestMove10BlocksNode2");
+    initialize(db2, storage2, p2p2, validatorPrivKeys[1], rdpos2, options2, state2, 8081, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode2");
 
     std::unique_ptr<DB> db3;
     std::unique_ptr<Storage> storage3;
@@ -754,7 +758,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos3;
     std::unique_ptr<Options> options3;
     std::unique_ptr<State> state3;
-    initialize(db3, storage3, p2p3, validatorPrivKeys[2], rdpos3, options3, state3, 8082, true, "rdPoSdiscoveryNodeTestMove10BlocksNode3");
+    initialize(db3, storage3, p2p3, validatorPrivKeys[2], rdpos3, options3, state3, 8082, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode3");
 
     std::unique_ptr<DB> db4;
     std::unique_ptr<Storage> storage4;
@@ -763,7 +767,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos4;
     std::unique_ptr<Options> options4;
     std::unique_ptr<State> state4;
-    initialize(db4, storage4, p2p4, validatorPrivKeys[3], rdpos4, options4, state4, 8083, true, "rdPoSdiscoveryNodeTestMove10BlocksNode4");
+    initialize(db4, storage4, p2p4, validatorPrivKeys[3], rdpos4, options4, state4, 8083, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode4");
 
     std::unique_ptr<DB> db5;
     std::unique_ptr<Storage> storage5;
@@ -772,7 +776,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos5;
     std::unique_ptr<Options> options5;
     std::unique_ptr<State> state5;
-    initialize(db5, storage5, p2p5, validatorPrivKeys[4], rdpos5, options5, state5, 8084, true, "rdPoSdiscoveryNodeTestMove10BlocksNode5");
+    initialize(db5, storage5, p2p5, validatorPrivKeys[4], rdpos5, options5, state5, 8084, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode5");
 
     std::unique_ptr<DB> db6;
     std::unique_ptr<Storage> storage6;
@@ -781,7 +785,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos6;
     std::unique_ptr<Options> options6;
     std::unique_ptr<State> state6;
-    initialize(db6, storage6, p2p6, validatorPrivKeys[5], rdpos6, options6, state6, 8085, true, "rdPoSdiscoveryNodeTestMove10BlocksNode6");
+    initialize(db6, storage6, p2p6, validatorPrivKeys[5], rdpos6, options6, state6, 8085, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode6");
 
     std::unique_ptr<DB> db7;
     std::unique_ptr<Storage> storage7;
@@ -790,7 +794,7 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos7;
     std::unique_ptr<Options> options7;
     std::unique_ptr<State> state7;
-    initialize(db7, storage7, p2p7, validatorPrivKeys[6], rdpos7, options7, state7, 8086, true, "rdPoSdiscoveryNodeTestMove10BlocksNode7");
+    initialize(db7, storage7, p2p7, validatorPrivKeys[6], rdpos7, options7, state7, 8086, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode7");
 
     std::unique_ptr<DB> db8;
     std::unique_ptr<Storage> storage8;
@@ -799,12 +803,12 @@ namespace TRdPoS {
     std::unique_ptr<rdPoS> rdpos8;
     std::unique_ptr<Options> options8;
     std::unique_ptr<State> state8;
-    initialize(db8, storage8, p2p8, validatorPrivKeys[7], rdpos8, options8, state8, 8087, true, "rdPoSdiscoveryNodeTestMove10BlocksNode8");
+    initialize(db8, storage8, p2p8, validatorPrivKeys[7], rdpos8, options8, state8, 8087, true, testDumpPath + "/rdPoSdiscoveryNodeTestMove10BlocksNode8");
 
     // Initialize the discovery node.
     std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
     std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-      "rdPoSdiscoveryNodeTestMove10Blocks",
+      testDumpPath + "/rdPoSdiscoveryNodeTestMove10Blocks",
       "OrbiterSDK/cpp/linux_x86-64/0.1.2",
       1,
       8080,

--- a/tests/core/state.cpp
+++ b/tests/core/state.cpp
@@ -2124,8 +2124,8 @@ namespace TState {
               /// We need to firstly create the contract!
               std::string tokenName = "TestToken";
               std::string tokenSymbol = "TT";
-              uint256_t tokenDecimals = 18;
-              uint256_t tokenSupply = 1000000000000000000;
+              uint256_t tokenDecimals = uint256_t(18);
+              uint256_t tokenSupply = uint256_t(1000000000000000000);
 
               ABI::Encoder::EncVar createNewERC20ContractVars;
               createNewERC20ContractVars.push_back(tokenName);
@@ -2156,7 +2156,7 @@ namespace TState {
 
               ABI::Encoder::EncVar transferVars;
               transferVars.push_back(targetOfTransactions);
-              transferVars.push_back(10000000000000000);
+              transferVars.push_back(uint256_t(10000000000000000));
               ABI::Encoder transferEncoder(transferVars);
               Bytes transferData = Hex::toBytes("0xa9059cbb");
               Utils::appendBytes(transferData, transferEncoder.getData());

--- a/tests/core/state.cpp
+++ b/tests/core/state.cpp
@@ -107,6 +107,7 @@ void initialize(std::unique_ptr<DB>& db,
 }
 
 namespace TState {
+  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("State Class", "[core][state]") {
     SECTION("State Class Constructor/Destructor", "[state]") {
       {
@@ -116,7 +117,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateConstructorTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateConstructorTest");
         REQUIRE(state->getNativeBalance(Address(Hex::toBytes("0x00dead00665771855a34155f5e7405489df2c3c6"))) ==
                 uint256_t("1000000000000000000000"));
       }
@@ -129,7 +130,7 @@ namespace TState {
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
       //// Check if opening the state loads successfully from DB.
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, "stateConstructorTest");
+      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/stateConstructorTest");
       REQUIRE(state->getNativeBalance(Address(Hex::toBytes("0x00dead00665771855a34155f5e7405489df2c3c6"))) ==
               uint256_t("1000000000000000000000"));
       REQUIRE(state->getNativeNonce(Address(Hex::toBytes("0x00dead00665771855a34155f5e7405489df2c3c6"))) == 0);
@@ -144,7 +145,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateAddBalanceTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateAddBalanceTest");
 
         for (uint64_t i = 0; i < 1024; ++i) {
           std::pair<Address, uint256_t> randomAddress = std::make_pair(Address(Utils::randBytes(20)),
@@ -167,7 +168,7 @@ namespace TState {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, "stateAddBalanceTest");
+      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/stateAddBalanceTest");
       for (const auto &[address, expectedBalance]: addresses) {
         REQUIRE(state->getNativeBalance(address) == expectedBalance);
         REQUIRE(state->getNativeNonce(address) == 0);
@@ -183,7 +184,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateSimpleBlockTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateSimpleBlockTest");
 
         auto newBlock = createValidBlock(rdpos, storage);
         REQUIRE(state->validateNextBlock(newBlock));
@@ -196,7 +197,7 @@ namespace TState {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, "stateSimpleBlockTest");
+      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/stateSimpleBlockTest");
 
       REQUIRE(latestBlock->hash() == storage->latest()->hash());
     }
@@ -216,7 +217,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateSimpleBlockTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateSimpleBlockTest");
 
         /// Add balance to the random Accounts and create random transactions
         std::vector<TxBlock> transactions;
@@ -274,7 +275,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateSimpleBlockTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateSimpleBlockTest");
 
         /// Add balance to the random Accounts and add tx's to directly to mempool.
         for (auto &[privkey, val]: randomAccounts) {
@@ -339,7 +340,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "stateSimpleBlockTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/stateSimpleBlockTest");
 
         /// Add balance to the random Accounts and add tx's to directly to mempool.
         std::vector<TxBlock> txs;
@@ -412,7 +413,7 @@ namespace TState {
         std::unique_ptr<rdPoS> rdpos;
         std::unique_ptr<State> state;
         std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, "state10BlocksTest");
+        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/state10BlocksTest");
         /// Add balance to the given addresses
         for (const auto &[privkey, account]: randomAccounts) {
           Address me = Secp256k1::toAddress(Secp256k1::toUPub(privkey));
@@ -464,7 +465,7 @@ namespace TState {
       std::unique_ptr<rdPoS> rdpos;
       std::unique_ptr<State> state;
       std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, "state10BlocksTest");
+      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/state10BlocksTest");
 
       REQUIRE(latestBlock->hash() == storage->latest()->hash());
       REQUIRE(storage->latest()->getNHeight() == 10);
@@ -491,7 +492,7 @@ namespace TState {
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
       initialize(db1, storage1, p2p1, rdpos1, state1, options1, validatorPrivKeys[0], 8080, true,
-                 "stateNode1NetworkCapabilities");
+                 testDumpPath + "/stateNode1NetworkCapabilities");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -501,7 +502,7 @@ namespace TState {
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
       initialize(db2, storage2, p2p2, rdpos2, state2, options2, validatorPrivKeys[1], 8081, true,
-                 "stateNode2NetworkCapabilities");
+                  testDumpPath + "/stateNode2NetworkCapabilities");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -511,7 +512,7 @@ namespace TState {
       std::unique_ptr<State> state3;
       std::unique_ptr<Options> options3;
       initialize(db3, storage3, p2p3, rdpos3, state3, options3, validatorPrivKeys[2], 8082, true,
-                 "stateNode3NetworkCapabilities");
+                  testDumpPath + "/stateNode3NetworkCapabilities");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -521,7 +522,7 @@ namespace TState {
       std::unique_ptr<State> state4;
       std::unique_ptr<Options> options4;
       initialize(db4, storage4, p2p4, rdpos4, state4, options4, validatorPrivKeys[3], 8083, true,
-                 "stateNode4NetworkCapabilities");
+                  testDumpPath + "/stateNode4NetworkCapabilities");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -531,7 +532,7 @@ namespace TState {
       std::unique_ptr<State> state5;
       std::unique_ptr<Options> options5;
       initialize(db5, storage5, p2p5, rdpos5, state5, options5, validatorPrivKeys[4], 8084, true,
-                 "stateNode5NetworkCapabilities");
+                  testDumpPath + "/stateNode5NetworkCapabilities");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -541,7 +542,7 @@ namespace TState {
       std::unique_ptr<State> state6;
       std::unique_ptr<Options> options6;
       initialize(db6, storage6, p2p6, rdpos6, state6, options6, validatorPrivKeys[5], 8085, true,
-                 "stateNode6NetworkCapabilities");
+                  testDumpPath + "/stateNode6NetworkCapabilities");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -551,7 +552,7 @@ namespace TState {
       std::unique_ptr<State> state7;
       std::unique_ptr<Options> options7;
       initialize(db7, storage7, p2p7, rdpos7, state7, options7, validatorPrivKeys[6], 8086, true,
-                 "stateNode7NetworkCapabilities");
+                  testDumpPath + "/stateNode7NetworkCapabilities");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -561,7 +562,7 @@ namespace TState {
       std::unique_ptr<State> state8;
       std::unique_ptr<Options> options8;
       initialize(db8, storage8, p2p8, rdpos8, state8, options8, validatorPrivKeys[7], 8087, true,
-                 "stateNode8NetworkCapabilities");
+                  testDumpPath + "/stateNode8NetworkCapabilities");
 
       // Initialize state with all balances
       for (const auto &privkey: randomAccounts) {
@@ -579,7 +580,7 @@ namespace TState {
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "stateDiscoveryNodeNetworkCapabilities",
+          testDumpPath + "/stateDiscoveryNodeNetworkCapabilities",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,
@@ -760,7 +761,7 @@ namespace TState {
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
       initialize(db1, storage1, p2p1, rdpos1, state1, options1, validatorPrivKeys[0], 8080, true,
-                 "stateNode1NetworkCapabilities");
+                  testDumpPath + "/stateNode1NetworkCapabilities");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -770,7 +771,7 @@ namespace TState {
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
       initialize(db2, storage2, p2p2, rdpos2, state2, options2, validatorPrivKeys[1], 8081, true,
-                 "stateNode2NetworkCapabilities");
+                  testDumpPath + "/stateNode2NetworkCapabilities");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -780,7 +781,7 @@ namespace TState {
       std::unique_ptr<State> state3;
       std::unique_ptr<Options> options3;
       initialize(db3, storage3, p2p3, rdpos3, state3, options3, validatorPrivKeys[2], 8082, true,
-                 "stateNode3NetworkCapabilities");
+                  testDumpPath + "/stateNode3NetworkCapabilities");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -790,7 +791,7 @@ namespace TState {
       std::unique_ptr<State> state4;
       std::unique_ptr<Options> options4;
       initialize(db4, storage4, p2p4, rdpos4, state4, options4, validatorPrivKeys[3], 8083, true,
-                 "stateNode4NetworkCapabilities");
+                  testDumpPath + "/stateNode4NetworkCapabilities");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -800,7 +801,7 @@ namespace TState {
       std::unique_ptr<State> state5;
       std::unique_ptr<Options> options5;
       initialize(db5, storage5, p2p5, rdpos5, state5, options5, validatorPrivKeys[4], 8084, true,
-                 "stateNode5NetworkCapabilities");
+                  testDumpPath + "/stateNode5NetworkCapabilities");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -810,7 +811,7 @@ namespace TState {
       std::unique_ptr<State> state6;
       std::unique_ptr<Options> options6;
       initialize(db6, storage6, p2p6, rdpos6, state6, options6, validatorPrivKeys[5], 8085, true,
-                 "stateNode6NetworkCapabilities");
+                  testDumpPath + "/stateNode6NetworkCapabilities");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -820,7 +821,7 @@ namespace TState {
       std::unique_ptr<State> state7;
       std::unique_ptr<Options> options7;
       initialize(db7, storage7, p2p7, rdpos7, state7, options7, validatorPrivKeys[6], 8086, true,
-                 "stateNode7NetworkCapabilities");
+                  testDumpPath + "/stateNode7NetworkCapabilities");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -830,12 +831,12 @@ namespace TState {
       std::unique_ptr<State> state8;
       std::unique_ptr<Options> options8;
       initialize(db8, storage8, p2p8, rdpos8, state8, options8, validatorPrivKeys[7], 8087, true,
-                 "stateNode8NetworkCapabilities");
+                  testDumpPath + "/stateNode8NetworkCapabilities");
 
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "stateDiscoveryNodeNetworkCapabilities",
+          testDumpPath + "/stateDiscoveryNodeNetworkCapabilities",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,
@@ -1076,7 +1077,7 @@ namespace TState {
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
       initialize(db1, storage1, p2p1, rdpos1, state1, options1, validatorPrivKeys[0], 8080, true,
-                 "stateNode1NetworkCapabilitiesWithTx");
+                 testDumpPath + "/stateNode1NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -1086,7 +1087,7 @@ namespace TState {
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
       initialize(db2, storage2, p2p2, rdpos2, state2, options2, validatorPrivKeys[1], 8081, true,
-                 "stateNode2NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode2NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -1096,7 +1097,7 @@ namespace TState {
       std::unique_ptr<State> state3;
       std::unique_ptr<Options> options3;
       initialize(db3, storage3, p2p3, rdpos3, state3, options3, validatorPrivKeys[2], 8082, true,
-                 "stateNode3NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode3NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -1106,7 +1107,7 @@ namespace TState {
       std::unique_ptr<State> state4;
       std::unique_ptr<Options> options4;
       initialize(db4, storage4, p2p4, rdpos4, state4, options4, validatorPrivKeys[3], 8083, true,
-                 "stateNode4NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode4NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -1116,7 +1117,7 @@ namespace TState {
       std::unique_ptr<State> state5;
       std::unique_ptr<Options> options5;
       initialize(db5, storage5, p2p5, rdpos5, state5, options5, validatorPrivKeys[4], 8084, true,
-                 "stateNode5NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode5NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -1126,7 +1127,7 @@ namespace TState {
       std::unique_ptr<State> state6;
       std::unique_ptr<Options> options6;
       initialize(db6, storage6, p2p6, rdpos6, state6, options6, validatorPrivKeys[5], 8085, true,
-                 "stateNode6NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode6NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -1136,7 +1137,7 @@ namespace TState {
       std::unique_ptr<State> state7;
       std::unique_ptr<Options> options7;
       initialize(db7, storage7, p2p7, rdpos7, state7, options7, validatorPrivKeys[6], 8086, true,
-                 "stateNode7NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode7NetworkCapabilitiesWithTx");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -1146,12 +1147,12 @@ namespace TState {
       std::unique_ptr<State> state8;
       std::unique_ptr<Options> options8;
       initialize(db8, storage8, p2p8, rdpos8, state8, options8, validatorPrivKeys[7], 8087, true,
-                 "stateNode8NetworkCapabilitiesWithTx");
+                  testDumpPath + "/stateNode8NetworkCapabilitiesWithTx");
 
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "statedDiscoveryNodeNetworkCapabilitiesWithTx",
+          testDumpPath + "/statedDiscoveryNodeNetworkCapabilitiesWithTx",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,
@@ -1451,7 +1452,7 @@ namespace TState {
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
       initialize(db1, storage1, p2p1, rdpos1, state1, options1, validatorPrivKeys[0], 8080, true,
-                 "stateNode1NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode1NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -1461,7 +1462,7 @@ namespace TState {
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
       initialize(db2, storage2, p2p2, rdpos2, state2, options2, validatorPrivKeys[1], 8081, true,
-                 "stateNode2NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode2NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -1471,7 +1472,7 @@ namespace TState {
       std::unique_ptr<State> state3;
       std::unique_ptr<Options> options3;
       initialize(db3, storage3, p2p3, rdpos3, state3, options3, validatorPrivKeys[2], 8082, true,
-                 "stateNode3NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode3NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -1481,7 +1482,7 @@ namespace TState {
       std::unique_ptr<State> state4;
       std::unique_ptr<Options> options4;
       initialize(db4, storage4, p2p4, rdpos4, state4, options4, validatorPrivKeys[3], 8083, true,
-                 "stateNode4NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode4NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -1491,7 +1492,7 @@ namespace TState {
       std::unique_ptr<State> state5;
       std::unique_ptr<Options> options5;
       initialize(db5, storage5, p2p5, rdpos5, state5, options5, validatorPrivKeys[4], 8084, true,
-                 "stateNode5NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode5NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -1501,7 +1502,7 @@ namespace TState {
       std::unique_ptr<State> state6;
       std::unique_ptr<Options> options6;
       initialize(db6, storage6, p2p6, rdpos6, state6, options6, validatorPrivKeys[5], 8085, true,
-                 "stateNode6NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode6NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -1511,7 +1512,7 @@ namespace TState {
       std::unique_ptr<State> state7;
       std::unique_ptr<Options> options7;
       initialize(db7, storage7, p2p7, rdpos7, state7, options7, validatorPrivKeys[6], 8086, true,
-                 "stateNode7NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode7NetworkCapabilitiesWithTxBlockBroadcast");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -1521,12 +1522,12 @@ namespace TState {
       std::unique_ptr<State> state8;
       std::unique_ptr<Options> options8;
       initialize(db8, storage8, p2p8, rdpos8, state8, options8, validatorPrivKeys[7], 8087, true,
-                 "stateNode8NetworkCapabilitiesWithTxBlockBroadcast");
+                  testDumpPath + "/stateNode8NetworkCapabilitiesWithTxBlockBroadcast");
 
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
+          testDumpPath + "/statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,
@@ -1844,7 +1845,7 @@ namespace TState {
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
       initialize(db1, storage1, p2p1, rdpos1, state1, options1, validatorPrivKeys[0], 8080, true,
-                 "stateNode1NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                 testDumpPath + "/stateNode1NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -1854,7 +1855,7 @@ namespace TState {
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
       initialize(db2, storage2, p2p2, rdpos2, state2, options2, validatorPrivKeys[1], 8081, true,
-                 "stateNode2NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                  testDumpPath + "/stateNode2NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db3;
       std::unique_ptr<Storage> storage3;
@@ -1864,7 +1865,7 @@ namespace TState {
       std::unique_ptr<State> state3;
       std::unique_ptr<Options> options3;
       initialize(db3, storage3, p2p3, rdpos3, state3, options3, validatorPrivKeys[2], 8082, true,
-                 "stateNode3NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                  testDumpPath + "/stateNode3NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db4;
       std::unique_ptr<Storage> storage4;
@@ -1874,7 +1875,7 @@ namespace TState {
       std::unique_ptr<State> state4;
       std::unique_ptr<Options> options4;
       initialize(db4, storage4, p2p4, rdpos4, state4, options4, validatorPrivKeys[3], 8083, true,
-                 "stateNode4NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                  testDumpPath + "/stateNode4NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db5;
       std::unique_ptr<Storage> storage5;
@@ -1884,7 +1885,7 @@ namespace TState {
       std::unique_ptr<State> state5;
       std::unique_ptr<Options> options5;
       initialize(db5, storage5, p2p5, rdpos5, state5, options5, validatorPrivKeys[4], 8084, true,
-                 "stateNode5NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                  testDumpPath + "/stateNode5NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db6;
       std::unique_ptr<Storage> storage6;
@@ -1894,7 +1895,7 @@ namespace TState {
       std::unique_ptr<State> state6;
       std::unique_ptr<Options> options6;
       initialize(db6, storage6, p2p6, rdpos6, state6, options6, validatorPrivKeys[5], 8085, true,
-                 "stateNode6NetworkCapabilitiesWithERC20TxBlockBroadcast");
+                  testDumpPath + "/stateNode6NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db7;
       std::unique_ptr<Storage> storage7;
@@ -1904,7 +1905,7 @@ namespace TState {
       std::unique_ptr<State> state7;
       std::unique_ptr<Options> options7;
       initialize(db7, storage7, p2p7, rdpos7, state7, options7, validatorPrivKeys[6], 8086, true,
-                 "stateNode7NetworkCapabilitiesWithTxERC20BlockBroadcast");
+                  testDumpPath + "/stateNode7NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       std::unique_ptr<DB> db8;
       std::unique_ptr<Storage> storage8;
@@ -1914,12 +1915,12 @@ namespace TState {
       std::unique_ptr<State> state8;
       std::unique_ptr<Options> options8;
       initialize(db8, storage8, p2p8, rdpos8, state8, options8, validatorPrivKeys[7], 8087, true,
-                 "stateNode8NetworkCapabilitiesWithTxERC20BlockBroadcast");
+                  testDumpPath + "/stateNode8NetworkCapabilitiesWithERC20TxBlockBroadcast");
 
       // Initialize the discovery node.
       std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
       std::unique_ptr<Options> discoveryOptions = std::make_unique<Options>(
-          "statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
+          testDumpPath + "/statedDiscoveryNodeNetworkCapabilitiesWithTxBlockBroadcast",
           "OrbiterSDK/cpp/linux_x86-64/0.1.2",
           1,
           8080,

--- a/tests/core/storage.cpp
+++ b/tests/core/storage.cpp
@@ -9,16 +9,17 @@
 // Initialize db to be used in tests.
 // DB here is the same
 void initialize(std::unique_ptr<DB> &db, std::unique_ptr<Storage>& storage, std::unique_ptr<Options>& options, bool clearDB = true) {
+  std::string testDumpPath = Utils::getTestDumpPath();
   if (clearDB) {
-    if (std::filesystem::exists("blocksTests")) {
-      std::filesystem::remove_all("blocksTests");
+    if (std::filesystem::exists(testDumpPath + "/blocksTests")) {
+      std::filesystem::remove_all(testDumpPath + "/blocksTests");
     }
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  db = std::make_unique<DB>("blocksTests/db");
+  db = std::make_unique<DB>(testDumpPath + "/blocksTests/db");
   std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
   options = std::make_unique<Options>(
-    "blocksTests",
+    testDumpPath + "/blocksTests",
     "OrbiterSDK/cpp/linux_x86-64/0.1.2",
     1,
     8080,

--- a/tests/net/http/httpjsonrpc.cpp
+++ b/tests/net/http/httpjsonrpc.cpp
@@ -185,7 +185,8 @@ namespace THTTPJsonRPC{
       std::unique_ptr<State> state;
       std::unique_ptr<HTTPServer> httpServer;
       std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, httpServer, options, validatorPrivKeys[0], 8080, 8081, true, "HTTPjsonRPC");
+      std::string testDumpPath = Utils::getTestDumpPath();
+      initialize(db, storage, p2p, rdpos, state, httpServer, options, validatorPrivKeys[0], 8080, 8081, true, testDumpPath + "/HTTPjsonRPC");
 
 
       /// Make random transactions within a given block, we need to include requests for getting txs and blocks

--- a/tests/net/p2p/p2p.cpp
+++ b/tests/net/p2p/p2p.cpp
@@ -11,6 +11,7 @@ using Catch::Matchers::Equals;
 
 namespace TP2P {
 
+  std::string testDumpPath = Utils::getTestDumpPath();
   void initializeOptions(std::unique_ptr<Options>& options, std::string folderPath, uint64_t serverPort) {
     std::vector<std::pair<boost::asio::ip::address, uint64_t>> peers;
     options = std::make_unique<Options>(
@@ -116,9 +117,9 @@ namespace TP2P {
       std::unique_ptr<Options> options1;
       std::unique_ptr<Options> options2;
       std::unique_ptr<Options> options3;
-      initializeOptions(options1, "testP2PManagerSimpleNetworkNode1", 8080);
-      initializeOptions(options2, "testP2PManagerSimpleNetworkNode2", 8081);
-      initializeOptions(options3, "testP2PManagerSimpleNetworkNode3", 8082);
+      initializeOptions(options1, testDumpPath + "/testP2PManagerSimpleNetworkNode1", 8080);
+      initializeOptions(options2, testDumpPath + "/testP2PManagerSimpleNetworkNode2", 8081);
+      initializeOptions(options3, testDumpPath + "/testP2PManagerSimpleNetworkNode3", 8082);
       P2P::ManagerNormal p2pNode1(boost::asio::ip::address::from_string("127.0.0.1"), nullptr, options1, nullptr, nullptr);
       P2P::ManagerNormal p2pNode2(boost::asio::ip::address::from_string("127.0.0.1"), nullptr, options2, nullptr, nullptr);
       P2P::ManagerNormal p2pNode3(boost::asio::ip::address::from_string("127.0.0.1"), nullptr, options3, nullptr, nullptr);
@@ -264,7 +265,7 @@ namespace TP2P {
       std::unique_ptr<rdPoS> rdpos1;
       std::unique_ptr<State> state1;
       std::unique_ptr<Options> options1;
-      initializeFullChain(db1, storage1, p2p1, rdpos1, state1, options1, PrivKey(), 8080, true, "p2pRequestInfoNode1");
+      initializeFullChain(db1, storage1, p2p1, rdpos1, state1, options1, PrivKey(), 8080, true, testDumpPath + "/p2pRequestInfoNode1");
 
       std::unique_ptr<DB> db2;
       std::unique_ptr<Storage> storage2;
@@ -272,7 +273,7 @@ namespace TP2P {
       std::unique_ptr<rdPoS> rdpos2;
       std::unique_ptr<State> state2;
       std::unique_ptr<Options> options2;
-      initializeFullChain(db2, storage2, p2p2, rdpos2, state2, options2, PrivKey(), 8081, true, "p2pRequestInfoNode2");
+      initializeFullChain(db2, storage2, p2p2, rdpos2, state2, options2, PrivKey(), 8081, true, testDumpPath + "/p2pRequestInfoNode2");
 
       /// Start the servers
       p2p1->start();
@@ -307,17 +308,17 @@ namespace TP2P {
       std::unique_ptr<Options> options9;
       std::unique_ptr<Options> options10;
       std::unique_ptr<Options> optionsDiscovery;
-      initializeOptions(optionsDiscovery, "testP2PManagerDiscoveryNetworkNodeDiscovery", 8090);
-      initializeOptions(options1, "testP2PManagerDiscoveryNetworkNode1", 8080);
-      initializeOptions(options2, "testP2PManagerDiscoveryNetworkNode2", 8081);
-      initializeOptions(options3, "testP2PManagerDiscoveryNetworkNode3", 8082);
-      initializeOptions(options4, "testP2PManagerDiscoveryNetworkNode4", 8083);
-      initializeOptions(options5, "testP2PManagerDiscoveryNetworkNode5", 8084);
-      initializeOptions(options6, "testP2PManagerDiscoveryNetworkNode6", 8085);
-      initializeOptions(options7, "testP2PManagerDiscoveryNetworkNode7", 8086);
-      initializeOptions(options8, "testP2PManagerDiscoveryNetworkNode8", 8087);
-      initializeOptions(options9, "testP2PManagerDiscoveryNetworkNode9", 8088);
-      initializeOptions(options10, "testP2PManagerDiscoveryNetworkNode10", 8089);
+      initializeOptions(optionsDiscovery, testDumpPath + "/testP2PManagerDiscoveryNetworkNodeDiscovery", 8090);
+      initializeOptions(options1, testDumpPath + "/testP2PManagerDiscoveryNetworkNode1", 8080);
+      initializeOptions(options2, testDumpPath + "/testP2PManagerDiscoveryNetworkNode2", 8081);
+      initializeOptions(options3, testDumpPath + "/testP2PManagerDiscoveryNetworkNode3", 8082);
+      initializeOptions(options4, testDumpPath + "/testP2PManagerDiscoveryNetworkNode4", 8083);
+      initializeOptions(options5, testDumpPath + "/testP2PManagerDiscoveryNetworkNode5", 8084);
+      initializeOptions(options6, testDumpPath + "/testP2PManagerDiscoveryNetworkNode6", 8085);
+      initializeOptions(options7, testDumpPath + "/testP2PManagerDiscoveryNetworkNode7", 8086);
+      initializeOptions(options8, testDumpPath + "/testP2PManagerDiscoveryNetworkNode8", 8087);
+      initializeOptions(options9, testDumpPath + "/testP2PManagerDiscoveryNetworkNode9", 8088);
+      initializeOptions(options10, testDumpPath + "/testP2PManagerDiscoveryNetworkNode10", 8089);
 
       P2P::ManagerDiscovery p2pDiscoveryNode(boost::asio::ip::address::from_string("127.0.0.1"), optionsDiscovery);
       P2P::ManagerNormal p2pNode1(boost::asio::ip::address::from_string("127.0.0.1"), nullptr, options1, nullptr, nullptr);

--- a/tests/utils/options.cpp
+++ b/tests/utils/options.cpp
@@ -5,9 +5,10 @@
 
 namespace TOptions {
   TEST_CASE("Option Class", "[core][options]") {
+    std::string testDumpPath = Utils::getTestDumpPath();
     SECTION("Options from File (default)") {
       Options optionsWithPrivKey(
-        "optionClassFromFileWithPrivKey",
+        testDumpPath + "/optionClassFromFileWithPrivKey",
         "OrbiterSDK/cpp/linux_x86-64/0.1.2",
         1,
         8080,
@@ -17,7 +18,7 @@ namespace TOptions {
         PrivKey(Hex::toBytes("0xb254f12b4ca3f0120f305cabf1188fe74f0bd38e58c932a3df79c4c55df8fa66"))
       );
 
-      Options optionsFromFileWithPrivKey(Options::fromFile("optionClassFromFileWithPrivKey"));
+      Options optionsFromFileWithPrivKey(Options::fromFile(testDumpPath + "/optionClassFromFileWithPrivKey"));
 
       REQUIRE(optionsFromFileWithPrivKey.getRootPath() == optionsWithPrivKey.getRootPath());
       REQUIRE(optionsFromFileWithPrivKey.getSDKVersion() == optionsWithPrivKey.getSDKVersion());


### PR DESCRIPTION
This PR introduces full SafeInt and int support in the SDK. We can use SafeInts in the same way that we use SafeUints, being necessary to import utils.h to access the definitions:

```c++
using SafeInt8_t = SafeInt_t<8>; ///< Typedef for SafeInt8_t.
using SafeInt16_t = SafeInt_t<16>; ///< Typedef for SafeInt16_t.
using SafeInt24_t = SafeInt_t<24>; ///< Typedef for SafeInt24_t.
using SafeInt32_t = SafeInt_t<32>; ///< Typedef for SafeInt32_t.
using SafeInt40_t = SafeInt_t<40>; ///< Typedef for SafeInt40_t.
using SafeInt48_t = SafeInt_t<48>; ///< Typedef for SafeInt48_t.
using SafeInt56_t = SafeInt_t<56>; ///< Typedef for SafeInt56_t.
using SafeInt64_t = SafeInt_t<64>; ///< Typedef for SafeInt64_t.
using SafeInt72_t = SafeInt_t<72>; ///< Typedef for SafeInt72_t.
using SafeInt80_t = SafeInt_t<80>; ///< Typedef for SafeInt80_t.
using SafeInt88_t = SafeInt_t<88>; ///< Typedef for SafeInt88_t.
using SafeInt96_t = SafeInt_t<96>; ///< Typedef for SafeInt96_t.
using SafeInt104_t = SafeInt_t<104>; ///< Typedef for SafeInt104_t.
using SafeInt112_t = SafeInt_t<112>; ///< Typedef for SafeInt112_t.
using SafeInt120_t = SafeInt_t<120>; ///< Typedef for SafeInt120_t.
using SafeInt128_t = SafeInt_t<128>; ///< Typedef for SafeInt128_t.
using SafeInt136_t = SafeInt_t<136>; ///< Typedef for SafeInt136_t.
using SafeInt144_t = SafeInt_t<144>; ///< Typedef for SafeInt144_t.
using SafeInt152_t = SafeInt_t<152>; ///< Typedef for SafeInt152_t.
using SafeInt160_t = SafeInt_t<160>; ///< Typedef for SafeInt160_t.
using SafeInt168_t = SafeInt_t<168>; ///< Typedef for SafeInt168_t.
using SafeInt176_t = SafeInt_t<176>; ///< Typedef for SafeInt176_t.
using SafeInt184_t = SafeInt_t<184>; ///< Typedef for SafeInt184_t.
using SafeInt192_t = SafeInt_t<192>; ///< Typedef for SafeInt192_t.
using SafeInt200_t = SafeInt_t<200>; ///< Typedef for SafeInt200_t.
using SafeInt208_t = SafeInt_t<208>; ///< Typedef for SafeInt208_t.
using SafeInt216_t = SafeInt_t<216>; ///< Typedef for SafeInt216_t.
using SafeInt224_t = SafeInt_t<224>; ///< Typedef for SafeInt224_t.
using SafeInt232_t = SafeInt_t<232>; ///< Typedef for SafeInt232_t.
using SafeInt240_t = SafeInt_t<240>; ///< Typedef for SafeInt240_t.
using SafeInt248_t = SafeInt_t<248>; ///< Typedef for SafeInt248_t.
using SafeInt256_t = SafeInt_t<256>; ///< Typedef for SafeInt256_t.
```

Encoding and decoding functionalities were properly implemented and tested, as well as conversion between intrinsic type and bytes.

