### PR TITLE
Change std::vector<Event> for MultiIndex Container

### DIFF
--- a/src/contract/contractmanager.cpp
+++ b/src/contract/contractmanager.cpp
@@ -246,6 +246,12 @@ std::vector<Event> ContractManager::getEvents(
   return this->eventManager_->getEvents(fromBlock, toBlock, address, topics);
 }
 
+std::vector<Event> ContractManager::getEvents(
+  const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+) {
+  return this->eventManager_->getEvents(txHash, blockIndex, txIndex);
+}
+
 void ContractManager::updateContractGlobals(const Address& coinbase, const Hash& blockHash, const uint64_t& blockHeight, const uint64_t& blockTimestamp) {
   ContractGlobals::coinbase_ = coinbase;
   ContractGlobals::blockHash_ = blockHash;

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -245,10 +245,21 @@ class ContractManager : BaseContract {
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
      * @param topics The topics to filter by. If empty, will look for all available topics.
-     * @return A list of matching events, limited by the block and/or log caps set above.
+     * @return A list of matching events.
      */
     std::vector<Event> getEvents(
       const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+    );
+
+    /**
+     * Overload of getEvents() for transaction receipts.
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
     );
 
     /**

--- a/src/contract/event.cpp
+++ b/src/contract/event.cpp
@@ -14,7 +14,7 @@ Event::Event(const std::string& jsonstr) {
   this->anonymous_ = obj["anonymous"].get<bool>();
 }
 
-std::string Event::serialize() {
+std::string Event::serialize() const {
   json topicArr = json::array();
   for (const Hash& b : this->topics_) topicArr.push_back(b.hex(true).get());
   json obj = {
@@ -52,8 +52,8 @@ std::string Event::serializeForRPC() {
 EventManager::EventManager(const std::unique_ptr<DB>& db) : db_(db) {
   std::vector<DBEntry> allEvents = this->db_->getBatch(DBPrefix::events);
   for (DBEntry& event : allEvents) {
-    Event e(Utils::bytesToString(event.value)); // Create a new Event object by deserializing the JSON string
-    this->events_.push_back(std::move(e)); // Move the object into the list
+    Event e(Utils::bytesToString(event.value)); // Create a new Event object by deserializing
+    this->events_.insert(std::move(e)); // Use insert for MultiIndex container
   }
 }
 
@@ -61,16 +61,15 @@ EventManager::~EventManager() {
   DBBatch batchedOperations;
   {
     std::unique_lock<std::shared_mutex> lock(this->lock_);
-    for (auto it = this->events_.begin(); it != this->events_.end(); it++) {
-      // Build the key (block height + address + tx index + log index)
-      Bytes key;
-      key.reserve(8 + key.size() + 8 + 8);
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getBlockIndex()));
-      Utils::appendBytes(key, it->getAddress().asBytes());
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getTxIndex()));
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getLogIndex()));
+    for (const auto& event : this->events_) {
+      // Build the key (address + block height + tx index + log index)
+      Bytes key = event.getAddress().asBytes();
+      key.reserve(key.size() + 8 + 8 + 8);
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getBlockIndex()));
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getTxIndex()));
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getLogIndex()));
       // Serialize the value to a JSON string and insert into the batch
-      batchedOperations.push_back(key, Utils::stringToBytes(it->serialize()), DBPrefix::events);
+      batchedOperations.push_back(key, Utils::stringToBytes(event.serialize()), DBPrefix::events);
     }
   }
   // Batch save to database and clear the list
@@ -87,24 +86,26 @@ std::vector<Event> EventManager::getEvents(
   // Throw if block height diff is greater than the block cap
   uint64_t heightDiff = std::max(fromBlock, toBlock) - std::min(fromBlock, toBlock);
   if (heightDiff > this->blockCap_) throw std::runtime_error(
-    "Block range too large for event querying! Max allowed is " + this->blockCap_
+    "Block range too large for event querying! Max allowed is " + std::to_string(this->blockCap_)
   );
 
-  // Get events in memory first
-  for (const Event& e : this->events_) {
-    if ((fromBlock <= e.getBlockIndex() <= toBlock) && (address != Address() || address == e.getAddress())) {
-      if (!topics.empty()) {
-        bool hasTopic = true;
-        const std::vector<Hash>& eventTopics = e.getTopics();
-        if (eventTopics.size() < topics.size()) continue; // Skip if topic quantity is not the exact same
-        for (size_t i = 0; i < topics.size(); i++) {  // Check if all topics actually match
-          if (topics.at(i) != eventTopics.at(i)) { hasTopic = false; break; }
-        }
-        if (!hasTopic) continue;
+  // Query the MultiIndex container
+  auto& blockIndexIndex = this->events_.get<0>(); // Assuming blockIndex_ is the first index
+  for (auto it = blockIndexIndex.lower_bound(fromBlock); it != blockIndexIndex.upper_bound(toBlock); ++it) {
+    const Event& e = *it;
+    if ((address != Address() && e.getAddress() != address)) continue;
+
+    if (!topics.empty()) {
+      bool hasTopic = true;
+      const std::vector<Hash>& eventTopics = e.getTopics();
+      if (eventTopics.size() < topics.size()) continue;
+      for (size_t i = 0; i < topics.size(); i++) {
+        if (topics.at(i) != eventTopics.at(i)) { hasTopic = false; break; }
       }
-      ret.push_back(e);
-      if (ret.size() >= this->logCap_) return ret;
+      if (!hasTopic) continue;
     }
+    ret.push_back(e);
+    if (ret.size() >= this->logCap_) return ret;
   }
 
   // Check relevant keys in the database, limiting the query to the specified block range
@@ -116,24 +117,24 @@ std::vector<Event> EventManager::getEvents(
     Utils::appendBytes(fromBytes, address.asBytes());
     Utils::appendBytes(toBytes, address.asBytes());
   }
+
   for (Bytes key : this->db_->getKeys(DBPrefix::events, fromBytes, toBytes)) {
-    // (0, 8) = block height, (8, 20) = address
     uint64_t blockHeight = Utils::bytesToUint64(Utils::create_view_span(key, 0, 8));
     Address add(Utils::create_view_span(key, 8, 20));
-    if ((fromBlock <= blockHeight <= toBlock) && (address != Address() || address == add)) {
+    if ((fromBlock <= blockHeight && blockHeight <= toBlock) && (address != Address() || address == add)) {
       dbKeys.push_back(key);
-      if (ret.size() + dbKeys.size() >= this->logCap_) break; // Stop checking when we know we'll reach log cap
+      if (ret.size() + dbKeys.size() >= this->logCap_) break;
     }
   }
 
-  // Get events in the database
+  // Get events from the database
   for (DBEntry item : this->db_->getBatch(DBPrefix::events, dbKeys)) {
     Event e(Utils::bytesToString(item.value));
     if (!topics.empty()) {
       bool hasTopic = true;
       const std::vector<Hash>& eventTopics = e.getTopics();
-      if (eventTopics.size() < topics.size()) continue; // Skip if topic quantity is not the exact same
-      for (size_t i = 0; i < topics.size(); i++) {  // Check if all topics actually match
+      if (eventTopics.size() < topics.size()) continue;
+      for (size_t i = 0; i < topics.size(); i++) {
         if (topics.at(i) != eventTopics.at(i)) { hasTopic = false; break; }
       }
       if (!hasTopic) continue;

--- a/src/contract/event.cpp
+++ b/src/contract/event.cpp
@@ -14,7 +14,7 @@ Event::Event(const std::string& jsonstr) {
   this->anonymous_ = obj["anonymous"].get<bool>();
 }
 
-std::string Event::serialize() {
+std::string Event::serialize() const {
   json topicArr = json::array();
   for (const Hash& b : this->topics_) topicArr.push_back(b.hex(true).get());
   json obj = {
@@ -52,8 +52,8 @@ std::string Event::serializeForRPC() {
 EventManager::EventManager(const std::unique_ptr<DB>& db) : db_(db) {
   std::vector<DBEntry> allEvents = this->db_->getBatch(DBPrefix::events);
   for (DBEntry& event : allEvents) {
-    Event e(Utils::bytesToString(event.value)); // Create a new Event object by deserializing the JSON string
-    this->events_.push_back(std::move(e)); // Move the object into the list
+    Event e(Utils::bytesToString(event.value)); // Create a new Event object by deserializing
+    this->events_.insert(std::move(e));
   }
 }
 
@@ -61,16 +61,15 @@ EventManager::~EventManager() {
   DBBatch batchedOperations;
   {
     std::unique_lock<std::shared_mutex> lock(this->lock_);
-    for (auto it = this->events_.begin(); it != this->events_.end(); it++) {
-      // Build the key (block height + address + tx index + log index)
-      Bytes key;
-      key.reserve(8 + key.size() + 8 + 8);
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getBlockIndex()));
-      Utils::appendBytes(key, it->getAddress().asBytes());
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getTxIndex()));
-      Utils::appendBytes(key, Utils::uint64ToBytes(it->getLogIndex()));
+    for (const auto& event : this->events_) {
+      // Build the key (address + block height + tx index + log index)
+      Bytes key = event.getAddress().asBytes();
+      key.reserve(key.size() + 8 + 8 + 8);
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getBlockIndex()));
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getTxIndex()));
+      Utils::appendBytes(key, Utils::uint64ToBytes(event.getLogIndex()));
       // Serialize the value to a JSON string and insert into the batch
-      batchedOperations.push_back(key, Utils::stringToBytes(it->serialize()), DBPrefix::events);
+      batchedOperations.push_back(key, Utils::stringToBytes(event.serialize()), DBPrefix::events);
     }
   }
   // Batch save to database and clear the list
@@ -79,69 +78,95 @@ EventManager::~EventManager() {
 }
 
 std::vector<Event> EventManager::getEvents(
-  const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+    const uint64_t& fromBlock, const uint64_t& toBlock, 
+    const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
 ) {
-  std::vector<Event> ret;
-  std::vector<Bytes> dbKeys;
+    std::vector<Event> ret;
 
-  // Throw if block height diff is greater than the block cap
-  uint64_t heightDiff = std::max(fromBlock, toBlock) - std::min(fromBlock, toBlock);
-  if (heightDiff > this->blockCap_) throw std::runtime_error(
-    "Block range too large for event querying! Max allowed is " + this->blockCap_
-  );
+    // Check if the block range is within limits
+    uint64_t heightDiff = std::max(fromBlock, toBlock) - std::min(fromBlock, toBlock);
+    if (heightDiff > this->blockCap_) {
+        throw std::runtime_error("Block range too large for event grepping!");
+    }
 
-  // Get events in memory first
-  for (const Event& e : this->events_) {
-    if ((fromBlock <= e.getBlockIndex() <= toBlock) && (address != Address() || address == e.getAddress())) {
-      if (!topics.empty()) {
-        bool hasTopic = true;
-        const std::vector<Hash>& eventTopics = e.getTopics();
-        if (eventTopics.size() < topics.size()) continue; // Skip if topic quantity is not the exact same
-        for (size_t i = 0; i < topics.size(); i++) {  // Check if all topics actually match
-          if (topics.at(i) != eventTopics.at(i)) { hasTopic = false; break; }
+    // Step 1: Initial Filtering from MultiIndex Container
+    std::vector<Event> filteredEvents = filterEventsInMemory(fromBlock, toBlock, address);
+
+    // Step 2: Manual Topic Matching for In-Memory Events
+    for (const Event& event : filteredEvents) {
+        if (matchTopics(event, topics) && ret.size() < this->logCap_) {
+            ret.push_back(event);
         }
-        if (!hasTopic) continue;
-      }
-      ret.push_back(e);
-      if (ret.size() >= this->logCap_) return ret;
     }
-  }
 
-  // Check relevant keys in the database, limiting the query to the specified block range
-  Bytes fromBytes;
-  Bytes toBytes;
-  Utils::appendBytes(fromBytes, Utils::uint64ToBytes(fromBlock));
-  Utils::appendBytes(toBytes, Utils::uint64ToBytes(toBlock));
-  if (address != Address()) {
-    Utils::appendBytes(fromBytes, address.asBytes());
-    Utils::appendBytes(toBytes, address.asBytes());
-  }
-  for (Bytes key : this->db_->getKeys(DBPrefix::events, fromBytes, toBytes)) {
-    // (0, 8) = block height, (8, 20) = address
-    uint64_t blockHeight = Utils::bytesToUint64(Utils::create_view_span(key, 0, 8));
-    Address add(Utils::create_view_span(key, 8, 20));
-    if ((fromBlock <= blockHeight <= toBlock) && (address != Address() || address == add)) {
-      dbKeys.push_back(key);
-      if (ret.size() + dbKeys.size() >= this->logCap_) break; // Stop checking when we know we'll reach log cap
+    // Step 3: Fetch and Filter Events from the Database
+    if (ret.size() < this->logCap_) {
+        fetchAndFilterEventsFromDB(fromBlock, toBlock, address, topics, ret);
     }
-  }
 
-  // Get events in the database
-  for (DBEntry item : this->db_->getBatch(DBPrefix::events, dbKeys)) {
-    Event e(Utils::bytesToString(item.value));
-    if (!topics.empty()) {
-      bool hasTopic = true;
-      const std::vector<Hash>& eventTopics = e.getTopics();
-      if (eventTopics.size() < topics.size()) continue; // Skip if topic quantity is not the exact same
-      for (size_t i = 0; i < topics.size(); i++) {  // Check if all topics actually match
-        if (topics.at(i) != eventTopics.at(i)) { hasTopic = false; break; }
-      }
-      if (!hasTopic) continue;
+    return ret;
+}
+
+std::vector<Event> EventManager::filterEventsInMemory(const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address) {
+    std::vector<Event> filteredEvents;
+
+    if (address.has_value()) {
+        auto& addressIndex = events_.get<1>();
+        for (auto it = addressIndex.lower_bound(address.value());
+             it != addressIndex.end() && it->getBlockIndex() <= toBlock;
+             ++it) {
+            if (it->getBlockIndex() >= fromBlock) {
+                filteredEvents.push_back(*it);
+            }
+        }
+    } else {
+        auto& blockIndex = events_.get<0>();
+        // Capture 'fromBlock' and 'toBlock' explicitly in a lambda capture clause
+        for (const Event& e : blockIndex) {
+            if (e.getBlockIndex() >= fromBlock && e.getBlockIndex() <= toBlock) {
+                filteredEvents.push_back(e);
+            }
+        }
     }
-    ret.push_back(e);
-    if (ret.size() >= this->logCap_) return ret;
-  }
 
-  return ret;
+    return filteredEvents;
+}
+
+void EventManager::fetchAndFilterEventsFromDB(
+    const uint64_t& fromBlock, const uint64_t& toBlock, 
+    const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics, 
+    std::vector<Event>& ret
+) {
+    // Database fetching logic
+    std::vector<Bytes> dbKeys;
+    for (Bytes key : this->db_->getKeys(DBPrefix::events)) {
+        Address addr(Utils::create_view_span(key, 0, 20)); // Extract address from key
+        uint64_t blockHeight = Utils::bytesToUint64(Utils::create_view_span(key, 20, 8)); // Extract block height from key
+
+        if ((fromBlock <= blockHeight && blockHeight <= toBlock) && 
+            (!address.has_value() || address.value() == addr)) {
+            dbKeys.push_back(key);
+        }
+    }
+
+    for (DBEntry item : this->db_->getBatch(DBPrefix::events, dbKeys)) {
+        Event e(Utils::bytesToString(item.value));
+        if (matchTopics(e, topics) && ret.size() < this->logCap_) {
+            ret.push_back(e);
+        }
+    }
+}
+
+bool EventManager::matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics) {
+    if (!topics.has_value()) return true; // No topic filter applied
+    const std::vector<Hash>& eventTopics = event.getTopics();
+    if (eventTopics.size() < topics->size()) return false;
+
+    for (size_t i = 0; i < topics->size(); ++i) {
+        if ((*topics)[i] != eventTopics[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 

--- a/src/contract/event.cpp
+++ b/src/contract/event.cpp
@@ -78,6 +78,24 @@ EventManager::~EventManager() {
 }
 
 std::vector<Event> EventManager::getEvents(
+    const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+) {
+    std::vector<Event> ret;
+    auto& txHashIndex = events_.get<2>(); // txHash is the third index
+
+    // Find the event with the given txHash
+    auto it = txHashIndex.find(txHash);
+    if (it != txHashIndex.end()) {
+        const Event& e = *it;
+        // Optionally check blockIndex and txIndex???
+        if (e.getBlockIndex() == blockIndex && e.getTxIndex() == txIndex) {
+            ret.push_back(e);
+        }
+    }
+    return ret;
+}
+
+std::vector<Event> EventManager::getEvents(
     const uint64_t& fromBlock, const uint64_t& toBlock, 
     const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
 ) {

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -25,16 +25,16 @@ using json = nlohmann::ordered_json;
 class Event {
   friend struct event_indices;
   private:
-    std::string name_;            ///< Event name.
-    uint64_t logIndex_;           ///< Position of the event inside the block it was emitted from.
-    Hash txHash_;                 ///< Hash of the transaction that emitted the event.
-    uint64_t txIndex_;            ///< Position of the transaction inside the block the event was emitted from.
-    Hash blockHash_;              ///< Hash of the block that emitted the event.
-    uint64_t blockIndex_;         ///< Height of the block that the event was emitted from.
-    Address address_;             ///< Address that emitted the event.
-    Bytes data_;                  ///< Non-indexed arguments of the event.
-    std::vector<Hash> topics_;    ///< Indexed arguments of the event, limited to a max of 3 (4 for anonymous events). Topics are Hashes since they are all 32 bytes.
-    bool anonymous_;              ///< Whether the event is anonymous or not (its signature is indexed and searchable).
+    std::string name_;          ///< Event name.
+    uint64_t logIndex_;         ///< Position of the event inside the block it was emitted from.
+    Hash txHash_;               ///< Hash of the transaction that emitted the event.
+    uint64_t txIndex_;          ///< Position of the transaction inside the block the event was emitted from.
+    Hash blockHash_;            ///< Hash of the block that emitted the event.
+    uint64_t blockIndex_;       ///< Height of the block that the event was emitted from.
+    Address address_;           ///< Address that emitted the event.
+    Bytes data_;                ///< Non-indexed arguments of the event.
+    std::vector<Hash> topics_;  ///< Indexed arguments of the event, limited to a max of 3 (4 for anonymous events). Topics are Hashes since they are all 32 bytes.
+    bool anonymous_;            ///< Whether the event is anonymous or not (its signature is indexed and searchable).
 
   public:
     /**
@@ -46,33 +46,38 @@ class Event {
      * @param params The event's arguments. (a tuple of N std::pair<T, bool> where T is the type and bool is whether it's indexed or not)
      * @param anonymous Whether the event is anonymous or not. Defaults to false.
      */
-    template <typename... Args, bool... Flags>
-    Event(const std::string& name, Address address, const std::tuple<EventParam<Args, Flags>...>& params, bool anonymous = false)
-      : name_(name), address_(address), anonymous_(anonymous) {
-      /// Get the event's signature
+    template <typename... Args, bool... Flags> Event(
+      const std::string& name, Address address,
+      const std::tuple<EventParam<Args, Flags>...>& params,
+      bool anonymous = false
+    ) : name_(name), address_(address), anonymous_(anonymous) {
+      // Get the event's signature
       auto eventSignature = ABI::EventEncoder::encodeSignature<Args...>(name);
       std::vector<Hash> topics;
-      /// For each EventParam in the tuple where Flag is true, we must encode it with ABI::EventEncoder::encodeTopicSignature<T>
-      /// Where T is the type of the parameter. and append it to the topics vector
-      /// But for each EventParam in the tuple where Flag is false, we have to encode it with ABI::Encoder::encodeData<T...>
-      /// Where T... is all the types of the params tuple that is false. This should result in a single Bytes object.
-      /// This Bytes object should be appended to the data vector.
-      /// We use std::apply for indexed parameters because we need to iterate over the tuple.
+
+      // Process indexed parameters.
+      // For each EventParam in the tuple where Flag is true, encode it with
+      // ABI::EventEncoder::encodeTopicSignature<T>, where T is the type of the
+      // parameter, and append it to the topics vector.
+      // For each EventParam in the tuple where Flag is false, encode it with
+      // ABI::Encoder::encodeData<T...>, where T... is all the types of the
+      // params tuple that are false, which should result in a single Bytes
+      // object that should be appended to the data vector.
+      // We use std::apply for indexed parameters because we need to iterate over the tuple.
       Bytes encodedNonIndexed;
       std::apply([&](const auto&... param) {
-          // Process indexed parameters
-          (..., (param.isIndexed ? topics.push_back(ABI::EventEncoder::encodeTopicSignature(param.value)) : void()));
+        (..., (param.isIndexed ? topics.push_back(ABI::EventEncoder::encodeTopicSignature(param.value)) : void()));
       }, params);
 
-      /// For non-indexed parameters, we need to encode them all together
-      /// encodeEventData differs from ABI::Encoder::EncoderData where it skips indexed parameters
+      // For non-indexed parameters, we need to encode them all together.
+      // encodeEventData differs from ABI::Encoder::EncoderData where it skips indexed parameters.
       this->data_ = ABI::EventEncoder::encodeEventData(params);
-      if (!anonymous) {
-        this->topics_.push_back(eventSignature);
-      }
+      if (!anonymous) this->topics_.push_back(eventSignature);
       for (const auto& topic : topics) {
         if (this->topics_.size() >= 4) {
-          Logger::logToDebug(LogType::WARNING, Log::event, __func__, "Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed.");
+          Logger::logToDebug(LogType::WARNING, Log::event, __func__,
+            "Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed."
+          );
           break;
         }
         this->topics_.push_back(topic);
@@ -152,21 +157,17 @@ class Event {
     std::string serializeForRPC();
 };
 
+/// Multi-index container used for storing events in memory.
 struct event_indices : bmi::indexed_by<
-    // Ordered index by blockIndex for range queries
-    bmi::ordered_non_unique<
-        bmi::member<Event, uint64_t, &Event::blockIndex_>
-    >,
-    // Ordered index by address (optional)
-    bmi::ordered_non_unique<
-        bmi::member<Event, Address, &Event::address_>
-    >,
-    // Ordered unique index by txHash for direct access
-    bmi::ordered_unique<
-        bmi::member<Event, Hash, &Event::txHash_>
-    >
+  // Ordered index by blockIndex for range queries
+  bmi::ordered_non_unique<bmi::member<Event, uint64_t, &Event::blockIndex_>>,
+  // Ordered index by address (optional)
+  bmi::ordered_non_unique<bmi::member<Event, Address, &Event::address_>>,
+  // Ordered index by txHash for direct access
+  bmi::ordered_non_unique<bmi::member<Event, Hash, &Event::txHash_>>
 > {};
 
+/// Typedef for the event multi-index container.
 typedef bmi::multi_index_container<Event, event_indices> EventContainer;
 
 /**
@@ -175,9 +176,9 @@ typedef bmi::multi_index_container<Event, event_indices> EventContainer;
  */
 class EventManager {
   private:
-    // TODO: keep up to 1000 events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
-    EventContainer events_;             ///< List of all emitted events in memory.
-    EventContainer tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
+    // TODO: keep up to 1000 (maybe 10000? 100000? 1M seems too much) events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
+    EventContainer events_;                 ///< List of all emitted events in memory. Older ones FIRST, newer ones LAST.
+    EventContainer tempEvents_;             ///< List of temporary events waiting to be commited or reverted.
     const std::unique_ptr<DB>& db_;         ///< Reference pointer to the database.
     mutable std::shared_mutex lock_;        ///< Mutex for managing read/write access to the permanent events vector.
     const unsigned short blockCap_ = 2000;  ///< Maximum block range allowed for querying events (safety net).
@@ -197,10 +198,8 @@ class EventManager {
 
     /**
      * Get all the events emitted under the given inputs.
-     * Parameters are defined when calling "eth_getLogs" on an HTTP request
+     * Used by "eth_getLogs", from where parameters are defined on an HTTP request
      * (directly from the http/jsonrpc submodules, through handle_request() on httpparser).
-     * They're supposed to be all "optional" at that point, but here they're
-     * all required, even if all of them turn out to be empty.
      * @param fromBlock The initial block height to look for.
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
@@ -208,21 +207,54 @@ class EventManager {
      * @return A list of matching events, limited by the block and/or log caps set above.
      */
     std::vector<Event> getEvents(
-      const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
+      const uint64_t& fromBlock, const uint64_t& toBlock,
+      const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
     );
 
+    /**
+     * Overload of getEvents() used by "eth_getTransactionReceipts", where
+     * parameters are filtered differently (by exact tx, not a range).
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events, limited by the block and/or log caps set above.
+     */
     std::vector<Event> getEvents(
-    const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex);
-
-    bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
-
-    void fetchAndFilterEventsFromDB(
-    const uint64_t& fromBlock, const uint64_t& toBlock, 
-    const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics, 
-    std::vector<Event>& ret
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
     );
 
-    std::vector<Event> filterEventsInMemory(const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address);
+    /**
+     * Filter events in memory. Used by getEvents().
+     * @param fromBlock The starting block range to query.
+     * @param toBlock Tne ending block range to query.
+     * @param address The address to look for. If empty, will look for all available addresses.
+     * @return A list of found events.
+     */
+    std::vector<Event> filterFromMemory(
+      const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address
+    );
+
+    /**
+     * Query and filter events from the database. Used by getEvents().
+     * @param fromBlock The starting block range to query.
+     * @param toBlock Tne ending block range to query.
+     * @param address The address to look for. If empty, will look for all available addresses.
+     * @param topics The topics to filter by. If empty, will look for all available topics.
+     * @param ret The list to use as return.
+     */
+    void fetchAndFilterFromDB(
+      const uint64_t& fromBlock, const uint64_t& toBlock,
+      const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics,
+      std::vector<Event>& ret
+    );
+
+    /**
+     * Check if all topics of an event match the desired topics from a query.
+     * @param event The event to match.
+     * @param topics The queried topics to match for.
+     * @return `true` if all topics match, `false` otherwise.
+     */
+    bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
 
     /**
      * Register the event in the temporary list.
@@ -231,26 +263,23 @@ class EventManager {
      */
     void registerEvent(Event&& event) {this->tempEvents_.insert(std::move(event));}
 
-
     /**
      * Actually register events in the permanent list.
-     * @param tx The transaction that emitted the events.
+     * @param txHash The hash of the transaction that emitted the events.
+     * @param txIndex The index of the transaction inside the block that emitted the events.
      */
     void commitEvents(const Hash txHash, const uint64_t txIndex) {
       uint64_t logIndex = 0;
-
-      // Use iterators to loop through the MultiIndex container
-      auto it = tempEvents_.begin();
+      auto it = tempEvents_.begin(); // Use iterators to loop through the MultiIndex container
       while (it != tempEvents_.end()) {
-          // Since we can't modify the element directly, we make a copy, modify it, and then move it
-          Event e = *it; // Copy the event (since we can't modify it directly)
-          e.setStateData(logIndex, txHash, txIndex,
-                        ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight());
-
-          events_.insert(std::move(e)); // Move the modified event to the permanent container
-
-          it = tempEvents_.erase(it); // Erase from tempEvents_ and move to next element
-          logIndex++;
+        // Since we can't modify the element directly because iterators are const...
+        Event e = *it;                // ...we make a copy...
+        e.setStateData(logIndex, txHash, txIndex,
+          ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight()
+        );                            // ...modify it...
+        events_.insert(std::move(e)); // ...move it to the permanent container...
+        it = tempEvents_.erase(it);   // ...erase the original from the temp...
+        logIndex++;                   // ...and move on to the next
       }
     }
 

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -208,8 +208,18 @@ class EventManager {
      * @return A list of matching events, limited by the block and/or log caps set above.
      */
     std::vector<Event> getEvents(
-      const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+      const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
     );
+
+    bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
+
+    void fetchAndFilterEventsFromDB(
+    const uint64_t& fromBlock, const uint64_t& toBlock, 
+    const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics, 
+    std::vector<Event>& ret
+    );
+
+    std::vector<Event> filterEventsInMemory(const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address);
 
     /**
      * Register the event in the temporary list.

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -12,11 +12,18 @@
 #include "../utils/utils.h"
 #include "abi.h"
 #include "contract.h"
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+
+namespace bmi = boost::multi_index;
 
 using json = nlohmann::ordered_json;
 
 /// Abstraction of a Solidity event.
 class Event {
+  friend struct event_indices;
   private:
     std::string name_;            ///< Event name.
     uint64_t logIndex_;           ///< Position of the event inside the block it was emitted from.
@@ -136,7 +143,7 @@ class Event {
     }
 
     /// Serialize event data from the object to a JSON string.
-    std::string serialize();
+    std::string serialize() const;
 
     /**
      * Serialize event data to a JSON string, formatted to RPC response standards:
@@ -145,6 +152,23 @@ class Event {
     std::string serializeForRPC();
 };
 
+struct event_indices : bmi::indexed_by<
+    // Ordered index by blockIndex for range queries
+    bmi::ordered_non_unique<
+        bmi::member<Event, uint64_t, &Event::blockIndex_>
+    >,
+    // Ordered index by address (optional)
+    bmi::ordered_non_unique<
+        bmi::member<Event, Address, &Event::address_>
+    >,
+    // Ordered unique index by txHash for direct access
+    bmi::ordered_unique<
+        bmi::member<Event, Hash, &Event::txHash_>
+    >
+> {};
+
+typedef bmi::multi_index_container<Event, event_indices> EventContainer;
+
 /**
  * Class that holds all events emitted by contracts in the blockchain.
  * Responsible for registering, managing and saving/loading events to/from the database.
@@ -152,8 +176,8 @@ class Event {
 class EventManager {
   private:
     // TODO: keep up to 1000 events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
-    std::vector<Event> events_;             ///< List of all emitted events in memory.
-    std::vector<Event> tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
+    EventContainer events_;             ///< List of all emitted events in memory.
+    EventContainer tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
     const std::unique_ptr<DB>& db_;         ///< Reference pointer to the database.
     mutable std::shared_mutex lock_;        ///< Mutex for managing read/write access to the permanent events vector.
     const unsigned short blockCap_ = 2000;  ///< Maximum block range allowed for querying events (safety net).
@@ -192,7 +216,8 @@ class EventManager {
      * Keep in mind the original Event object is MOVED to the list.
      * @param event The event to register.
      */
-    void registerEvent(Event&& event) { this->tempEvents_.emplace_back(std::move(event)); }
+    void registerEvent(Event&& event) {this->tempEvents_.insert(std::move(event));}
+
 
     /**
      * Actually register events in the permanent list.
@@ -200,14 +225,20 @@ class EventManager {
      */
     void commitEvents(const Hash txHash, const uint64_t txIndex) {
       uint64_t logIndex = 0;
-      for (Event& e : this->tempEvents_) {
-        e.setStateData(logIndex, txHash, txIndex,
-          ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight()
-        );
-        this->events_.push_back(std::move(e));
-        logIndex++;
+
+      // Use iterators to loop through the MultiIndex container
+      auto it = tempEvents_.begin();
+      while (it != tempEvents_.end()) {
+          // Since we can't modify the element directly, we make a copy, modify it, and then move it
+          Event e = *it; // Copy the event (since we can't modify it directly)
+          e.setStateData(logIndex, txHash, txIndex,
+                        ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight());
+
+          events_.insert(std::move(e)); // Move the modified event to the permanent container
+
+          it = tempEvents_.erase(it); // Erase from tempEvents_ and move to next element
+          logIndex++;
       }
-      this->tempEvents_.clear();
     }
 
     /// Discard events in the temporary list.

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -211,6 +211,9 @@ class EventManager {
       const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
     );
 
+    std::vector<Event> getEvents(
+    const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex);
+
     bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
 
     void fetchAndFilterEventsFromDB(

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -2,7 +2,6 @@
 #define EVENT_H
 
 #include <algorithm>
-#include <optional>
 #include <shared_mutex>
 #include <string>
 
@@ -13,18 +12,11 @@
 #include "../utils/utils.h"
 #include "abi.h"
 #include "contract.h"
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/member.hpp>
 
-namespace bmi = boost::multi_index;
 using json = nlohmann::ordered_json;
 
 /// Abstraction of a Solidity event.
 class Event {
-
-  friend struct event_indices; // For multi_index_container
   private:
     std::string name_;            ///< Event name.
     uint64_t logIndex_;           ///< Position of the event inside the block it was emitted from.
@@ -144,7 +136,7 @@ class Event {
     }
 
     /// Serialize event data from the object to a JSON string.
-    std::string serialize() const;
+    std::string serialize();
 
     /**
      * Serialize event data to a JSON string, formatted to RPC response standards:
@@ -153,32 +145,15 @@ class Event {
     std::string serializeForRPC();
 };
 
-struct event_indices : bmi::indexed_by<
-    // Ordered index by blockIndex for range queries
-    bmi::ordered_non_unique<
-        bmi::member<Event, uint64_t, &Event::blockIndex_>
-    >,
-    // Ordered index by address (optional)
-    bmi::ordered_non_unique<
-        bmi::member<Event, Address, &Event::address_>
-    >,
-    // Ordered unique index by txHash for direct access
-    bmi::ordered_unique<
-        bmi::member<Event, Hash, &Event::txHash_>
-    >
-> {};
-
-typedef bmi::multi_index_container<Event, event_indices> EventContainer;
-
 /**
  * Class that holds all events emitted by contracts in the blockchain.
  * Responsible for registering, managing and saving/loading events to/from the database.
  */
 class EventManager {
   private:
-    // TODO: keep up to 1000 events in memory, dump older ones to DB (maybe this should be a deque?)
-    EventContainer events_;             ///< List of all emitted events in memory.
-    EventContainer tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
+    // TODO: keep up to 1000 events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
+    std::vector<Event> events_;             ///< List of all emitted events in memory.
+    std::vector<Event> tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
     const std::unique_ptr<DB>& db_;         ///< Reference pointer to the database.
     mutable std::shared_mutex lock_;        ///< Mutex for managing read/write access to the permanent events vector.
     const unsigned short blockCap_ = 2000;  ///< Maximum block range allowed for querying events (safety net).
@@ -209,26 +184,15 @@ class EventManager {
      * @return A list of matching events, limited by the block and/or log caps set above.
      */
     std::vector<Event> getEvents(
-      const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
+      const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
     );
-
-    bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
-
-    void fetchAndFilterEventsFromDB(
-    const uint64_t& fromBlock, const uint64_t& toBlock, 
-    const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics, 
-    std::vector<Event>& ret
-    );
-
-    std::vector<Event> filterEventsInMemory(const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address);
 
     /**
      * Register the event in the temporary list.
      * Keep in mind the original Event object is MOVED to the list.
      * @param event The event to register.
      */
-    void registerEvent(Event&& event) {this->events_.insert(std::move(event));}
-
+    void registerEvent(Event&& event) { this->tempEvents_.emplace_back(std::move(event)); }
 
     /**
      * Actually register events in the permanent list.
@@ -236,19 +200,15 @@ class EventManager {
      */
     void commitEvents(const Hash txHash, const uint64_t txIndex) {
       uint64_t logIndex = 0;
-      auto it = tempEvents_.begin();
-      while (it != tempEvents_.end()) {
-          // Since we can't modify the element directly, we make a copy, modify it, and then move it
-          Event e = *it;
-          e.setStateData(logIndex, txHash, txIndex,
-                        ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight());
-          events_.insert(std::move(e));
-          it = tempEvents_.erase(it);
-          logIndex++;
+      for (Event& e : this->tempEvents_) {
+        e.setStateData(logIndex, txHash, txIndex,
+          ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight()
+        );
+        this->events_.push_back(std::move(e));
+        logIndex++;
       }
-  }
-
-
+      this->tempEvents_.clear();
+    }
 
     /// Discard events in the temporary list.
     void revertEvents() { this->tempEvents_.clear(); }

--- a/src/core/state.cpp
+++ b/src/core/state.cpp
@@ -267,7 +267,7 @@ void State::processNextBlock(Block&& block) {
   }
 
   std::unique_lock lock(this->stateMutex_);
-  
+
   // Update contract globals based on (now) latest block
   const Hash blockHash = block.hash();
   this->contractManager_->updateContractGlobals(Secp256k1::toAddress(block.getValidatorPubKey()), blockHash, block.getNHeight(), block.getTimestamp());
@@ -388,5 +388,12 @@ std::vector<Event> State::getEvents(
 ) {
   std::shared_lock lock(this->stateMutex_);
   return this->contractManager_->getEvents(fromBlock, toBlock, address, topics);
+}
+
+std::vector<Event> State::getEvents(
+  const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+) {
+  std::shared_lock lock(this->stateMutex_);
+  return this->contractManager_->getEvents(txHash, blockIndex, txIndex);
 }
 

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -240,10 +240,21 @@ class State {
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
      * @param topics The topics to filter by. If empty, will look for all available topics.
-     * @return A list of matching events, limited by the block and/or log caps set above.
+     * @return A list of matching events.
      */
     std::vector<Event> getEvents(
       const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+    );
+
+    /**
+     * Overload of getEvents() for transaction receipts.
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
     );
 
     /// the Manager Interface cannot use getNativeBalance. as it will call a lock with the mutex.

--- a/src/net/http/httpparser.cpp
+++ b/src/net/http/httpparser.cpp
@@ -150,7 +150,7 @@ std::string parseJsonRpcRequest(
         break;
       case JsonRPC::Methods::eth_getTransactionReceipt:
         ret = JsonRPC::Encoding::eth_getTransactionReceipt(
-          JsonRPC::Decoding::eth_getTransactionReceipt(request), storage
+          JsonRPC::Decoding::eth_getTransactionReceipt(request), storage, state
         );
         break;
       default:

--- a/src/net/http/jsonrpc/encoding.h
+++ b/src/net/http/jsonrpc/encoding.h
@@ -248,9 +248,13 @@ namespace JsonRPC {
      * Encode a `eth_getTransactionReceipt` response.
      * @param txHash The transaction's hash.
      * @param storage Pointer to the blockchain's storage.
+     * @param state Pointer to the blockchain's state.
      * @return The encoded JSON response.
      */
-    json eth_getTransactionReceipt(const Hash& txHash, const std::unique_ptr<Storage>& storage);
+    json eth_getTransactionReceipt(
+      const Hash& txHash, const std::unique_ptr<Storage>& storage,
+      const std::unique_ptr<State>& state
+    );
   }
 }
 

--- a/src/utils/db.h
+++ b/src/utils/db.h
@@ -104,8 +104,10 @@ class DBBatch {
       tmp.reserve(prefix.size() + key.size());
       tmp.insert(tmp.end(), key.begin(), key.end());
       puts_.emplace_back(std::move(tmp), Bytes(value.begin(), value.end()));
-      putsSlices_.emplace_back(rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().key.data()), puts_.back().key.size()),
-                              rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().value.data()), puts_.back().value.size()));
+      putsSlices_.emplace_back(
+        rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().key.data()), puts_.back().key.size()),
+        rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().value.data()), puts_.back().value.size())
+      );
     }
 
     /**
@@ -118,7 +120,9 @@ class DBBatch {
       tmp.reserve(prefix.size() + key.size());
       tmp.insert(tmp.end(), key.begin(), key.end());
       dels_.emplace_back(std::move(tmp));
-      delsSlices_.emplace_back(rocksdb::Slice(reinterpret_cast<const char*>(dels_.back().data()), dels_.back().size()));
+      delsSlices_.emplace_back(
+        rocksdb::Slice(reinterpret_cast<const char*>(dels_.back().data()), dels_.back().size())
+      );
     }
 
     /**
@@ -155,7 +159,6 @@ class DB {
     rocksdb::DB* db_;              ///< Pointer to the database object itself.
     rocksdb::Options opts_;        ///< Struct with options for managing the database.
     mutable std::mutex batchLock_; ///< Mutex for managing read/write access to batch operations.
-    // TODO: add a custom comparator for more granular key comparisons (e.g. for events)
 
   public:
     /**
@@ -291,6 +294,7 @@ class DB {
      * Get all keys from a given prefix.
      * Ranges can be used to mitigate very expensive operations
      * (e.g. a query can return millions of entries).
+     * Prefix is automatically added to the queries themselves internally.
      * @param pfx The prefix to search keys from.
      * @param start (optional) The first key to start searching from.
      * @param end (optional) The last key to end searching at.

--- a/tests/contract/simplecontract.cpp
+++ b/tests/contract/simplecontract.cpp
@@ -168,6 +168,8 @@ namespace TSimpleContract {
 
         REQUIRE(nameEvent.getName() == "nameChanged");
         REQUIRE(nameEvent.getLogIndex() == 0);
+        std::cout << Hex::fromBytes(nameEvent.getTxHash().asBytes(), true).get() << std::endl;
+        std::cout << Hex::fromBytes(setNameTx.hash().asBytes(), true).get() << std::endl;
         REQUIRE(nameEvent.getTxHash() == setNameTx.hash());
         REQUIRE(nameEvent.getTxIndex() == 0);
         REQUIRE(nameEvent.getBlockIndex() == 0);


### PR DESCRIPTION
Use Boost MultiIndex container for representing a set of Events instead of plain std::vector.