### PR TITLE
SDK Test Suite Implementation

### DIFF
--- a/src/contract/abi.cpp
+++ b/src/contract/abi.cpp
@@ -31,61 +31,6 @@ Bytes ABI::Encoder::encodeInt(const int256_t& num) {
   return ret;
 }
 
-Bytes ABI::Encoder::encode(const Address& add) { return Utils::padLeftBytes(add.get(), 32); }
-
-Bytes ABI::Encoder::encode(const bool& b) { return Utils::padLeftBytes((b ? Bytes{0x01} : Bytes{0x00}), 32); }
-
-Bytes ABI::Encoder::encode(const Bytes &bytes) {
-  int pad = 0;
-  do { pad += 32; } while (pad < bytes.size());
-  Bytes len = Utils::padLeftBytes(Utils::uintToBytes(bytes.size()), 32);
-  Bytes data = Utils::padRightBytes(bytes, pad);
-  len.reserve(len.size() + data.size());
-  len.insert(len.end(), std::make_move_iterator(data.begin()), std::make_move_iterator(data.end()));
-  return len;
-}
-
-Bytes ABI::Encoder::encode(const std::string& str) {
-  BytesArrView bytes = Utils::create_view_span(str);
-  int pad = 0;
-  do { pad += 32; } while (pad < bytes.size());
-  Bytes len = Utils::padLeftBytes(Utils::uintToBytes(bytes.size()), 32);
-  Bytes data = Utils::padRightBytes(bytes, pad);
-  len.reserve(len.size() + data.size());
-  len.insert(len.end(), std::make_move_iterator(data.begin()), std::make_move_iterator(data.end()));
-  return len;
-}
-
-Bytes ABI::EventEncoder::encodeUint(const uint256_t& num) {
-  return Encoder::encodeUint(num);
-}
-
-Bytes ABI::EventEncoder::encodeInt(const int256_t& num) {
-  return Encoder::encodeInt(num);
-}
-
-Bytes ABI::EventEncoder::encode(const Address& add) {
-  return Encoder::encode(add);
-}
-
-Bytes ABI::EventEncoder::encode(const bool& b) {
-  return Encoder::encode(b);
-}
-
-Bytes ABI::EventEncoder::encode(const Bytes& bytes) {
-  /// Almost the same as ABI::Encoder::encode, but without the padding.
-  int pad = 0;
-  do { pad += 32; } while (pad < bytes.size());
-  return Utils::padRightBytes(bytes, pad);
-}
-
-Bytes ABI::EventEncoder::encode(const std::string& str) {
-  BytesArrView bytes = Utils::create_view_span(str);
-  int pad = 0;
-  do { pad += 32; } while (pad < bytes.size());
-  return Utils::padRightBytes(bytes, pad);
-}
-
 uint256_t ABI::Decoder::decodeUint(const BytesArrView &bytes, uint64_t &index) {
   if (index + 32 > bytes.size()) throw std::runtime_error("Data too short for uint256");
   uint256_t result = Utils::bytesToUint256(bytes.subspan(index, 32));

--- a/src/contract/abi.cpp
+++ b/src/contract/abi.cpp
@@ -73,7 +73,7 @@ Bytes ABI::EventEncoder::encode(const bool& b) {
 }
 
 Bytes ABI::EventEncoder::encode(const Bytes& bytes) {
-  /// Almost the sabe as ABI::Encoder::encode, but without the padding.
+  /// Almost the same as ABI::Encoder::encode, but without the padding.
   int pad = 0;
   do { pad += 32; } while (pad < bytes.size());
   return Utils::padRightBytes(bytes, pad);

--- a/src/contract/abi.h
+++ b/src/contract/abi.h
@@ -947,35 +947,6 @@ namespace ABI {
     };
 
     ///@endcond
-    // Helper struct to conditionally append a type to a tuple
-    template <bool Flag, typename T, typename Tuple>
-    struct conditional_tuple_append {
-        using type = Tuple;
-    };
-
-    template <typename T, typename... Ts>
-    struct conditional_tuple_append<false, T, std::tuple<Ts...>> {
-        using type = std::tuple<Ts..., T>;
-    };
-
-    template<typename Accumulated, typename... Rest>
-    struct makeTupleTypeHelper {
-        using type = Accumulated;
-    };
-
-    template<typename Accumulated, typename T, bool Flag, typename... Rest>
-    struct makeTupleTypeHelper<Accumulated, EventParam<T, Flag>, Rest...> {
-        using NextAccumulated = typename conditional_tuple_append<Flag, T, Accumulated>::type;
-        using type = typename makeTupleTypeHelper<NextAccumulated, Rest...>::type;
-    };
-
-    template<typename... Args>
-    struct makeTupleType;
-
-    template<typename... Args, bool... Flags>
-    struct makeTupleType<EventParam<Args, Flags>...> {
-        using type = typename makeTupleTypeHelper<std::tuple<>, EventParam<Args, Flags>...>::type;
-    };
 
     /**
      * Recursive helper function to decode each element of the tuple.

--- a/src/contract/contractfactory.h
+++ b/src/contract/contractfactory.h
@@ -55,8 +55,7 @@ class ContractFactory {
      * @throw runtime_error if non contract creator tries to create a contract.
      * @throw runtime_error if contract already exists.
      */
-    template <typename TContract>
-    auto setupNewContract(const ethCallInfo &callInfo) {
+    template <typename TContract> auto setupNewContract(const ethCallInfo &callInfo) {
       // Check if caller is creator
       if (this->manager_.getOrigin() != this->manager_.getContractCreator()) {
         throw std::runtime_error("Only contract creator can create new contracts");

--- a/src/contract/contractmanager.cpp
+++ b/src/contract/contractmanager.cpp
@@ -246,6 +246,12 @@ std::vector<Event> ContractManager::getEvents(
   return this->eventManager_->getEvents(fromBlock, toBlock, address, topics);
 }
 
+std::vector<Event> ContractManager::getEvents(
+  const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+) {
+  return this->eventManager_->getEvents(txHash, blockIndex, txIndex);
+}
+
 void ContractManager::updateContractGlobals(const Address& coinbase, const Hash& blockHash, const uint64_t& blockHeight, const uint64_t& blockTimestamp) {
   ContractGlobals::coinbase_ = coinbase;
   ContractGlobals::blockHash_ = blockHash;

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -245,10 +245,21 @@ class ContractManager : BaseContract {
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
      * @param topics The topics to filter by. If empty, will look for all available topics.
-     * @return A list of matching events, limited by the block and/or log caps set above.
+     * @return A list of matching events.
      */
     std::vector<Event> getEvents(
       const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+    );
+
+    /**
+     * Overload of getEvents() for transaction receipts.
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
     );
 
     /**

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -332,14 +332,18 @@ class ContractManagerInterface {
         this->sendTokens(fromAddr, targetAddr, value);
       }
       if (!this->manager_.contracts_.contains(targetAddr)) {
-        throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
+        throw std::runtime_error(std::string(__func__) + ": Contract does not exist - Type: "
+          + Utils::getRealTypeName<C>() + " at address: " + targetAddr.hex().get()
+        );
       }
       C* contract = this->getContract<C>(targetAddr);
       this->manager_.callLogger_->setContractVars(contract, txOrigin, fromAddr, value);
       try {
         return contract->callContractFunction(func, std::forward<const Args&>(args)...);
       } catch (const std::exception& e) {
-        throw std::runtime_error(e.what());
+        throw std::runtime_error(e.what() + std::string(" - Type: ")
+          + Utils::getRealTypeName<C>() + " at address: " + targetAddr.hex().get()
+        );
       }
     }
 
@@ -363,9 +367,7 @@ class ContractManagerInterface {
       if (!this->manager_.callLogger_) throw std::runtime_error(
         "Contracts going haywire! Trying to call ContractState without an active callContract"
       );
-      if (value) {
-        this->sendTokens(fromAddr, targetAddr, value);
-      }
+      if (value) this->sendTokens(fromAddr, targetAddr, value);
       if (!this->manager_.contracts_.contains(targetAddr)) {
         throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
       }
@@ -405,15 +407,16 @@ class ContractManagerInterface {
       createSignature += ")";
       auto& [from, to, gas, gasPrice, value, functor, data] = callInfo;
       from = fromAddr;
-      to = this->manager_.deriveContractAddress();
+      to = this->manager_.getContractAddress();
       gas = gasValue;
       gasPrice = gasPriceValue;
       value = callValue;
       functor = Utils::sha3(Utils::create_view_span(createSignature)).view_const(0, 4);
       data = encoder;
       this->manager_.callLogger_->setContractVars(&manager_, txOrigin, fromAddr, value);
+      Address newContractAddress = this->manager_.deriveContractAddress();
       this->manager_.ethCall(callInfo);
-      return to;
+      return newContractAddress;
     }
 
     /**

--- a/src/contract/contractmanager.h
+++ b/src/contract/contractmanager.h
@@ -330,10 +330,9 @@ class ContractManagerInterface {
       );
       if (value) {
         this->sendTokens(fromAddr, targetAddr, value);
-      } else {
-        if (!this->manager_.contracts_.contains(targetAddr)) {
-          throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
-        }
+      }
+      if (!this->manager_.contracts_.contains(targetAddr)) {
+        throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
       }
       C* contract = this->getContract<C>(targetAddr);
       this->manager_.callLogger_->setContractVars(contract, txOrigin, fromAddr, value);
@@ -366,10 +365,9 @@ class ContractManagerInterface {
       );
       if (value) {
         this->sendTokens(fromAddr, targetAddr, value);
-      } else {
-        if (!this->manager_.contracts_.contains(targetAddr)) {
-          throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
-        }
+      }
+      if (!this->manager_.contracts_.contains(targetAddr)) {
+        throw std::runtime_error(std::string(__func__) + ": Contract does not exist");
       }
       C* contract = this->getContract<C>(targetAddr);
       this->manager_.callLogger_->setContractVars(contract, txOrigin, fromAddr, value);

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -12,22 +12,29 @@
 #include "../utils/utils.h"
 #include "abi.h"
 #include "contract.h"
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+
+namespace bmi = boost::multi_index;
 
 using json = nlohmann::ordered_json;
 
 /// Abstraction of a Solidity event.
 class Event {
+  friend struct event_indices;
   private:
-    std::string name_;            ///< Event name.
-    uint64_t logIndex_;           ///< Position of the event inside the block it was emitted from.
-    Hash txHash_;                 ///< Hash of the transaction that emitted the event.
-    uint64_t txIndex_;            ///< Position of the transaction inside the block the event was emitted from.
-    Hash blockHash_;              ///< Hash of the block that emitted the event.
-    uint64_t blockIndex_;         ///< Height of the block that the event was emitted from.
-    Address address_;             ///< Address that emitted the event.
-    Bytes data_;                  ///< Non-indexed arguments of the event.
-    std::vector<Hash> topics_;    ///< Indexed arguments of the event, limited to a max of 3 (4 for anonymous events). Topics are Hashes since they are all 32 bytes.
-    bool anonymous_;              ///< Whether the event is anonymous or not (its signature is indexed and searchable).
+    std::string name_;          ///< Event name.
+    uint64_t logIndex_;         ///< Position of the event inside the block it was emitted from.
+    Hash txHash_;               ///< Hash of the transaction that emitted the event.
+    uint64_t txIndex_;          ///< Position of the transaction inside the block the event was emitted from.
+    Hash blockHash_;            ///< Hash of the block that emitted the event.
+    uint64_t blockIndex_;       ///< Height of the block that the event was emitted from.
+    Address address_;           ///< Address that emitted the event.
+    Bytes data_;                ///< Non-indexed arguments of the event.
+    std::vector<Hash> topics_;  ///< Indexed arguments of the event, limited to a max of 3 (4 for anonymous events). Topics are Hashes since they are all 32 bytes.
+    bool anonymous_;            ///< Whether the event is anonymous or not (its signature is indexed and searchable).
 
   public:
     /**
@@ -39,33 +46,38 @@ class Event {
      * @param params The event's arguments. (a tuple of N std::pair<T, bool> where T is the type and bool is whether it's indexed or not)
      * @param anonymous Whether the event is anonymous or not. Defaults to false.
      */
-    template <typename... Args, bool... Flags>
-    Event(const std::string& name, Address address, const std::tuple<EventParam<Args, Flags>...>& params, bool anonymous = false)
-      : name_(name), address_(address), anonymous_(anonymous) {
-      /// Get the event's signature
+    template <typename... Args, bool... Flags> Event(
+      const std::string& name, Address address,
+      const std::tuple<EventParam<Args, Flags>...>& params,
+      bool anonymous = false
+    ) : name_(name), address_(address), anonymous_(anonymous) {
+      // Get the event's signature
       auto eventSignature = ABI::EventEncoder::encodeSignature<Args...>(name);
       std::vector<Hash> topics;
-      /// For each EventParam in the tuple where Flag is true, we must encode it with ABI::EventEncoder::encodeTopicSignature<T>
-      /// Where T is the type of the parameter. and append it to the topics vector
-      /// But for each EventParam in the tuple where Flag is false, we have to encode it with ABI::Encoder::encodeData<T...>
-      /// Where T... is all the types of the params tuple that is false. This should result in a single Bytes object.
-      /// This Bytes object should be appended to the data vector.
-      /// We use std::apply for indexed parameters because we need to iterate over the tuple.
+
+      // Process indexed parameters.
+      // For each EventParam in the tuple where Flag is true, encode it with
+      // ABI::EventEncoder::encodeTopicSignature<T>, where T is the type of the
+      // parameter, and append it to the topics vector.
+      // For each EventParam in the tuple where Flag is false, encode it with
+      // ABI::Encoder::encodeData<T...>, where T... is all the types of the
+      // params tuple that are false, which should result in a single Bytes
+      // object that should be appended to the data vector.
+      // We use std::apply for indexed parameters because we need to iterate over the tuple.
       Bytes encodedNonIndexed;
       std::apply([&](const auto&... param) {
-          // Process indexed parameters
-          (..., (param.isIndexed ? topics.push_back(ABI::EventEncoder::encodeTopicSignature(param.value)) : void()));
+        (..., (param.isIndexed ? topics.push_back(ABI::EventEncoder::encodeTopicSignature(param.value)) : void()));
       }, params);
 
-      /// For non-indexed parameters, we need to encode them all together
-      /// encodeEventData differs from ABI::Encoder::EncoderData where it skips indexed parameters
+      // For non-indexed parameters, we need to encode them all together.
+      // encodeEventData differs from ABI::Encoder::EncoderData where it skips indexed parameters.
       this->data_ = ABI::EventEncoder::encodeEventData(params);
-      if (!anonymous) {
-        this->topics_.push_back(eventSignature);
-      }
+      if (!anonymous) this->topics_.push_back(eventSignature);
       for (const auto& topic : topics) {
         if (this->topics_.size() >= 4) {
-          Logger::logToDebug(LogType::WARNING, Log::event, __func__, "Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed.");
+          Logger::logToDebug(LogType::WARNING, Log::event, __func__,
+            "Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed."
+          );
           break;
         }
         this->topics_.push_back(topic);
@@ -136,7 +148,7 @@ class Event {
     }
 
     /// Serialize event data from the object to a JSON string.
-    std::string serialize();
+    std::string serialize() const;
 
     /**
      * Serialize event data to a JSON string, formatted to RPC response standards:
@@ -145,15 +157,28 @@ class Event {
     std::string serializeForRPC();
 };
 
+/// Multi-index container used for storing events in memory.
+struct event_indices : bmi::indexed_by<
+  // Ordered index by blockIndex for range queries
+  bmi::ordered_non_unique<bmi::member<Event, uint64_t, &Event::blockIndex_>>,
+  // Ordered index by address (optional)
+  bmi::ordered_non_unique<bmi::member<Event, Address, &Event::address_>>,
+  // Ordered index by txHash for direct access
+  bmi::ordered_non_unique<bmi::member<Event, Hash, &Event::txHash_>>
+> {};
+
+/// Typedef for the event multi-index container.
+typedef bmi::multi_index_container<Event, event_indices> EventContainer;
+
 /**
  * Class that holds all events emitted by contracts in the blockchain.
  * Responsible for registering, managing and saving/loading events to/from the database.
  */
 class EventManager {
   private:
-    // TODO: keep up to 1000 events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
-    std::vector<Event> events_;             ///< List of all emitted events in memory.
-    std::vector<Event> tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
+    // TODO: keep up to 1000 (maybe 10000? 100000? 1M seems too much) events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
+    EventContainer events_;                 ///< List of all emitted events in memory. Older ones FIRST, newer ones LAST.
+    EventContainer tempEvents_;             ///< List of temporary events waiting to be commited or reverted.
     const std::unique_ptr<DB>& db_;         ///< Reference pointer to the database.
     mutable std::shared_mutex lock_;        ///< Mutex for managing read/write access to the permanent events vector.
     const unsigned short blockCap_ = 2000;  ///< Maximum block range allowed for querying events (safety net).
@@ -173,10 +198,8 @@ class EventManager {
 
     /**
      * Get all the events emitted under the given inputs.
-     * Parameters are defined when calling "eth_getLogs" on an HTTP request
+     * Used by "eth_getLogs", from where parameters are defined on an HTTP request
      * (directly from the http/jsonrpc submodules, through handle_request() on httpparser).
-     * They're supposed to be all "optional" at that point, but here they're
-     * all required, even if all of them turn out to be empty.
      * @param fromBlock The initial block height to look for.
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
@@ -184,30 +207,80 @@ class EventManager {
      * @return A list of matching events, limited by the block and/or log caps set above.
      */
     std::vector<Event> getEvents(
-      const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+      const uint64_t& fromBlock, const uint64_t& toBlock,
+      const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics
     );
+
+    /**
+     * Overload of getEvents() used by "eth_getTransactionReceipts", where
+     * parameters are filtered differently (by exact tx, not a range).
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events, limited by the block and/or log caps set above.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+    );
+
+    /**
+     * Filter events in memory. Used by getEvents().
+     * @param fromBlock The starting block range to query.
+     * @param toBlock Tne ending block range to query.
+     * @param address The address to look for. If empty, will look for all available addresses.
+     * @return A list of found events.
+     */
+    std::vector<Event> filterFromMemory(
+      const uint64_t& fromBlock, const uint64_t& toBlock, const std::optional<Address>& address
+    );
+
+    /**
+     * Query and filter events from the database. Used by getEvents().
+     * @param fromBlock The starting block range to query.
+     * @param toBlock Tne ending block range to query.
+     * @param address The address to look for. If empty, will look for all available addresses.
+     * @param topics The topics to filter by. If empty, will look for all available topics.
+     * @param ret The list to use as return.
+     */
+    void fetchAndFilterFromDB(
+      const uint64_t& fromBlock, const uint64_t& toBlock,
+      const std::optional<Address>& address, const std::optional<std::vector<Hash>>& topics,
+      std::vector<Event>& ret
+    );
+
+    /**
+     * Check if all topics of an event match the desired topics from a query.
+     * @param event The event to match.
+     * @param topics The queried topics to match for.
+     * @return `true` if all topics match, `false` otherwise.
+     */
+    bool matchTopics(const Event& event, const std::optional<std::vector<Hash>>& topics);
 
     /**
      * Register the event in the temporary list.
      * Keep in mind the original Event object is MOVED to the list.
      * @param event The event to register.
      */
-    void registerEvent(Event&& event) { this->tempEvents_.emplace_back(std::move(event)); }
+    void registerEvent(Event&& event) {this->tempEvents_.insert(std::move(event));}
 
     /**
      * Actually register events in the permanent list.
-     * @param tx The transaction that emitted the events.
+     * @param txHash The hash of the transaction that emitted the events.
+     * @param txIndex The index of the transaction inside the block that emitted the events.
      */
     void commitEvents(const Hash txHash, const uint64_t txIndex) {
       uint64_t logIndex = 0;
-      for (Event& e : this->tempEvents_) {
+      auto it = tempEvents_.begin(); // Use iterators to loop through the MultiIndex container
+      while (it != tempEvents_.end()) {
+        // Since we can't modify the element directly because iterators are const...
+        Event e = *it;                // ...we make a copy...
         e.setStateData(logIndex, txHash, txIndex,
           ContractGlobals::getBlockHash(), ContractGlobals::getBlockHeight()
-        );
-        this->events_.push_back(std::move(e));
-        logIndex++;
+        );                            // ...modify it...
+        events_.insert(std::move(e)); // ...move it to the permanent container...
+        it = tempEvents_.erase(it);   // ...erase the original from the temp...
+        logIndex++;                   // ...and move on to the next
       }
-      this->tempEvents_.clear();
     }
 
     /// Discard events in the temporary list.

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -151,7 +151,7 @@ class Event {
  */
 class EventManager {
   private:
-    // TODO: keep up to 1000 events in memory, dump older ones to DB (maybe this should be a deque?)
+    // TODO: keep up to 1000 events in memory, dump older ones to DB (this includes checking save/load - maybe this should be a deque?)
     std::vector<Event> events_;             ///< List of all emitted events in memory.
     std::vector<Event> tempEvents_;         ///< List of temporary events waiting to be commited or reverted.
     const std::unique_ptr<DB>& db_;         ///< Reference pointer to the database.

--- a/src/contract/templates/dexv2/dexv2factory.h
+++ b/src/contract/templates/dexv2/dexv2factory.h
@@ -108,7 +108,7 @@ class DEXV2Factory : public DynamicContract {
 
     /// Register the contract functions to the ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         DEXV2Factory, const Address&,  ContractManagerInterface &,
         const Address &, const Address &, const uint64_t &,
         const std::unique_ptr<DB> &

--- a/src/contract/templates/dexv2/dexv2pair.h
+++ b/src/contract/templates/dexv2/dexv2pair.h
@@ -213,7 +213,7 @@ class DEXV2Pair : public ERC20 {
 
     /// Register contract class via ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         DEXV2Pair, ContractManagerInterface &,
         const Address &, const Address &, const uint64_t &,
         const std::unique_ptr<DB> &

--- a/src/contract/templates/dexv2/dexv2router02.h
+++ b/src/contract/templates/dexv2/dexv2router02.h
@@ -315,7 +315,7 @@ class DEXV2Router02 : public DynamicContract {
 
     /// Register the contract functions to the ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         DEXV2Router02, const Address &, const Address &, ContractManagerInterface &,
         const Address &, const Address &, const uint64_t &,
         const std::unique_ptr<DB> &

--- a/src/contract/templates/erc20.h
+++ b/src/contract/templates/erc20.h
@@ -187,7 +187,7 @@ class ERC20 : public DynamicContract {
 
     /// Register contract class via ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         ERC20, const std::string &, const std::string &, const uint8_t &,
         const uint256_t &, ContractManagerInterface &,
         const Address &, const Address &, const uint64_t &,

--- a/src/contract/templates/erc20wrapper.h
+++ b/src/contract/templates/erc20wrapper.h
@@ -64,7 +64,7 @@ class ERC20Wrapper : public DynamicContract {
 
     /// Register contract class via ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         ERC20Wrapper, ContractManagerInterface&,
         const Address&, const Address&, const uint64_t&,
         const std::unique_ptr<DB>&

--- a/src/contract/templates/erc721.h
+++ b/src/contract/templates/erc721.h
@@ -307,7 +307,7 @@ public:
 
   /// Register contract class via ContractReflectionInterface.
   static void registerContract() {
-    ContractReflectionInterface::registerContract<
+    ContractReflectionInterface::registerContractMethods<
         ERC721, const std::string &, const std::string &,
         ContractManagerInterface &, const Address &, const Address &,
         const uint64_t &, const std::unique_ptr<DB> &>(

--- a/src/contract/templates/nativewrapper.h
+++ b/src/contract/templates/nativewrapper.h
@@ -80,7 +80,7 @@ class NativeWrapper : public ERC20 {
 
     /// Register contract using ContractReflectionInterface.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         NativeWrapper, std::string &, std::string &, uint8_t &,
         ContractManagerInterface &, const Address &,
         const Address &, const uint64_t &, const std::unique_ptr<DB> &

--- a/src/contract/templates/simplecontract.cpp
+++ b/src/contract/templates/simplecontract.cpp
@@ -51,6 +51,7 @@ void SimpleContract::setNames(const std::vector<std::string>& argName) {
   }
   this->name_ = "";
   for (const auto& name : argName) this->name_ += name;
+  this->nameChanged(this->name_.get());
 }
 
 void SimpleContract::setValue(const uint256_t& argValue) {
@@ -64,6 +65,7 @@ void SimpleContract::setValue(const uint256_t& argValue) {
 void SimpleContract::setValues(const std::vector<uint256_t>& argValue) {
   this->value_ = 0;
   for (const auto& value : argValue) this->value_ += value;
+  this->valueChanged(this->value_.get());
 }
 
 void SimpleContract::setNamesAndValues(
@@ -76,6 +78,7 @@ void SimpleContract::setNamesAndValues(
   this->value_ = 0;
   for (const auto& name : argName) this->name_ += name;
   for (const auto& value : argValue) this->value_ += value;
+  this->nameAndValueChanged(this->name_.get(), this->value_.get());
 }
 
 void SimpleContract::setNamesAndValuesInTuple(
@@ -87,6 +90,7 @@ void SimpleContract::setNamesAndValuesInTuple(
   this->name_ = "";
   this->value_ = 0;
   for (const auto& [name, value] : argNameAndValue) { this->name_ += name; this->value_ += value; }
+  this->nameAndValueTupleChanged(std::make_tuple(this->name_.get(), this->value_.get()));
 }
 
 void SimpleContract::setNamesAndValuesInArrayOfArrays(
@@ -100,6 +104,7 @@ void SimpleContract::setNamesAndValuesInArrayOfArrays(
   for (const auto& nameAndValue : argNameAndValue) {
     for (const auto& [name, value] : nameAndValue) { this->name_ += name; this->value_ += value; }
   }
+  this->nameAndValueChanged(this->name_.get(), this->value_.get());
 }
 
 std::string SimpleContract::getName() const { return this->name_.get(); }

--- a/src/contract/templates/simplecontract.h
+++ b/src/contract/templates/simplecontract.h
@@ -22,7 +22,7 @@ class SimpleContract : public DynamicContract {
     SafeUint256_t value_; ///< The value of the contract.
     void registerContractFunctions() override; ///< Register the contract functions.
 
-  protected:
+  public:
     /// Event for when the name changes.
     void nameChanged(const EventParam<std::string, true>& name) { this->emitEvent(__func__,  std::make_tuple(name)); }
 
@@ -39,8 +39,7 @@ class SimpleContract : public DynamicContract {
       this->emitEvent(__func__, std::make_tuple(nameAndValue));
     }
 
-  public:
-    using ConstructorArguments = std::tuple<const std::string&, uint256_t>; ///< The constructor arguments type.
+    using ConstructorArguments = std::tuple<const std::string&, const uint256_t&>; ///< The constructor arguments type.
 
     /**
      * Constructor from create. Create contract and save it to database.

--- a/src/contract/templates/simplecontract.h
+++ b/src/contract/templates/simplecontract.h
@@ -24,7 +24,7 @@ class SimpleContract : public DynamicContract {
 
   public:
     /// Event for when the name changes.
-    void nameChanged(const EventParam<std::string, true>& name) { this->emitEvent(__func__,  std::make_tuple(name)); }
+    void nameChanged(const EventParam<std::string, false>& name) { this->emitEvent(__func__,  std::make_tuple(name)); }
 
     /// Event for when the value changes.
     void valueChanged(const EventParam<uint256_t, true>& value) { this->emitEvent(__func__, std::make_tuple(value)); }

--- a/src/contract/templates/simplecontract.h
+++ b/src/contract/templates/simplecontract.h
@@ -117,7 +117,7 @@ class SimpleContract : public DynamicContract {
 
     /// Register the contract structure.
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         SimpleContract, const std::string&, uint256_t,
         ContractManagerInterface&,
         const Address&, const Address&, const uint64_t&,

--- a/src/contract/templates/simplecontract.h
+++ b/src/contract/templates/simplecontract.h
@@ -24,10 +24,10 @@ class SimpleContract : public DynamicContract {
 
   public:
     /// Event for when the name changes.
-    void nameChanged(const EventParam<std::string, false>& name) { this->emitEvent(__func__,  std::make_tuple(name)); }
+    void nameChanged(const EventParam<std::string, true>& name) { this->emitEvent(__func__,  std::make_tuple(name)); }
 
     /// Event for when the value changes.
-    void valueChanged(const EventParam<uint256_t, true>& value) { this->emitEvent(__func__, std::make_tuple(value)); }
+    void valueChanged(const EventParam<uint256_t, false>& value) { this->emitEvent(__func__, std::make_tuple(value)); }
 
     /// Event for when the name and value change. used for testing json abi generation
     void nameAndValueChanged(const EventParam<std::string, true>& name, const EventParam<uint256_t, true>& value) {

--- a/src/contract/templates/throwtestA.h
+++ b/src/contract/templates/throwtestA.h
@@ -65,7 +65,7 @@ class ThrowTestA : public DynamicContract {
     * Register the contract structure.
     */
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         ThrowTestA, ContractManagerInterface&, const Address&, const Address&, const uint64_t&, const std::unique_ptr<DB>&
       >(
         std::vector<std::string>{},

--- a/src/contract/templates/throwtestB.h
+++ b/src/contract/templates/throwtestB.h
@@ -54,7 +54,7 @@ class ThrowTestB : public DynamicContract {
     * Register the contract structure.
     */
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         ThrowTestB, ContractManagerInterface&, const Address&, const Address&, const uint64_t&, const std::unique_ptr<DB>&
       >(
         std::vector<std::string>{},

--- a/src/contract/templates/throwtestC.h
+++ b/src/contract/templates/throwtestC.h
@@ -53,7 +53,7 @@ class ThrowTestC : public DynamicContract {
     * Register the contract structure.
     */
     static void registerContract() {
-      ContractReflectionInterface::registerContract<
+      ContractReflectionInterface::registerContractMethods<
         ThrowTestC, ContractManagerInterface&, const Address&, const Address&, const uint64_t&, const std::unique_ptr<DB>&
       >(
         std::vector<std::string>{},

--- a/src/core/rdpos.h
+++ b/src/core/rdpos.h
@@ -35,14 +35,6 @@ class State;
  */
 class Validator : public Address {
   public:
-    // Using parent operators.
-    using Address::operator==;
-    using Address::operator!=;
-    using Address::operator<;
-    using Address::operator<=;
-    using Address::operator>;
-    using Address::operator>=;
-
     /// Constructor.
     Validator(const Address& add) : Address(add) {}
 

--- a/src/core/state.cpp
+++ b/src/core/state.cpp
@@ -267,7 +267,7 @@ void State::processNextBlock(Block&& block) {
   }
 
   std::unique_lock lock(this->stateMutex_);
-  
+
   // Update contract globals based on (now) latest block
   const Hash blockHash = block.hash();
   this->contractManager_->updateContractGlobals(Secp256k1::toAddress(block.getValidatorPubKey()), blockHash, block.getNHeight(), block.getTimestamp());
@@ -388,5 +388,12 @@ std::vector<Event> State::getEvents(
 ) {
   std::shared_lock lock(this->stateMutex_);
   return this->contractManager_->getEvents(fromBlock, toBlock, address, topics);
+}
+
+std::vector<Event> State::getEvents(
+  const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+) {
+  std::shared_lock lock(this->stateMutex_);
+  return this->contractManager_->getEvents(txHash, blockIndex, txIndex);
 }
 

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -240,10 +240,21 @@ class State {
      * @param toBlock The final block height to look for.
      * @param address The address to look for. If empty, will look for all available addresses.
      * @param topics The topics to filter by. If empty, will look for all available topics.
-     * @return A list of matching events, limited by the block and/or log caps set above.
+     * @return A list of matching events.
      */
     std::vector<Event> getEvents(
       const uint64_t& fromBlock, const uint64_t& toBlock, const Address& address, const std::vector<Hash>& topics
+    );
+
+    /**
+     * Overload of getEvents() for transaction receipts.
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
     );
 
     /// the Manager Interface cannot use getNativeBalance. as it will call a lock with the mutex.

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -25,6 +25,8 @@ enum StorageStatus { NotFound, OnChain, OnCache, OnDB };
  * Abstraction of the blockchain history.
  * Used to store blocks in memory and on disk, and helps the State process
  * new blocks, transactions and RPC queries.
+ * TODO: Improve const correctness.
+ * Possible replace `std::shared_ptr<const Block>` with a better solution.
  */
 class Storage {
   private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,6 @@ See the LICENSE.txt file in the project root for more information.
 #include <filesystem>
 
 #include "src/core/blockchain.h"
-#include "src/contract/event.h"
 
 std::unique_ptr<Blockchain> blockchain = nullptr;
 
@@ -26,7 +25,7 @@ int main() {
   Utils::logToCout = true;
   std::string blockchainPath = std::filesystem::current_path().string() + std::string("/blockchain");
   blockchain = std::make_unique<Blockchain>(blockchainPath);
-  /// Start the blockchain syncing engine.
+  // Start the blockchain syncing engine.
   std::signal(SIGINT, signalHandler);
   std::signal(SIGHUP, signalHandler);
   blockchain->start();

--- a/src/net/http/httpparser.cpp
+++ b/src/net/http/httpparser.cpp
@@ -150,7 +150,7 @@ std::string parseJsonRpcRequest(
         break;
       case JsonRPC::Methods::eth_getTransactionReceipt:
         ret = JsonRPC::Encoding::eth_getTransactionReceipt(
-          JsonRPC::Decoding::eth_getTransactionReceipt(request), storage
+          JsonRPC::Decoding::eth_getTransactionReceipt(request), storage, state
         );
         break;
       default:

--- a/src/net/http/jsonrpc/decoding.cpp
+++ b/src/net/http/jsonrpc/decoding.cpp
@@ -461,9 +461,9 @@ namespace JsonRPC {
           if (logsObject.contains("toBlock")) {
             std::string toBlockHex = logsObject["toBlock"].get<std::string>();
             if (toBlockHex == "latest") {
-              fromBlock = storage->latest()->getNHeight();
+              toBlock = storage->latest()->getNHeight();
             } else if (toBlockHex == "earliest") {
-              fromBlock = 0;
+              toBlock = 0;
             } else if (toBlockHex == "pending") {
               throw std::runtime_error("Pending block is not supported");
             } else if (std::regex_match(toBlockHex, numFilter)) {

--- a/src/net/http/jsonrpc/decoding.cpp
+++ b/src/net/http/jsonrpc/decoding.cpp
@@ -458,7 +458,6 @@ namespace JsonRPC {
               throw std::runtime_error("Invalid fromBlock hex");
             }
           }
-
           if (logsObject.contains("toBlock")) {
             std::string toBlockHex = logsObject["toBlock"].get<std::string>();
             if (toBlockHex == "latest") {

--- a/src/net/http/jsonrpc/encoding.h
+++ b/src/net/http/jsonrpc/encoding.h
@@ -248,9 +248,13 @@ namespace JsonRPC {
      * Encode a `eth_getTransactionReceipt` response.
      * @param txHash The transaction's hash.
      * @param storage Pointer to the blockchain's storage.
+     * @param state Pointer to the blockchain's state.
      * @return The encoded JSON response.
      */
-    json eth_getTransactionReceipt(const Hash& txHash, const std::unique_ptr<Storage>& storage);
+    json eth_getTransactionReceipt(
+      const Hash& txHash, const std::unique_ptr<Storage>& storage,
+      const std::unique_ptr<State>& state
+    );
   }
 }
 

--- a/src/utils/contractreflectioninterface.cpp
+++ b/src/utils/contractreflectioninterface.cpp
@@ -38,5 +38,11 @@ namespace ContractReflectionInterface {
    * Multimap is used for overloaded events.
    */
   std::unordered_map<std::string, std::unordered_multimap<std::string, ABI::EventDescription>> eventDescsMap;
+
+  /**
+   * Map of pointer to member functions of contract methods.
+   * Key is a unique identifier derived from the pointer, value is a std::string of the function name.
+   */
+  std::unordered_map<UniqueFunctionPointerIdentifier, std::string, UniqueFunctionPointerIdentifier::Hash> pointerNamesMap;
 }
 

--- a/src/utils/contractreflectioninterface.h
+++ b/src/utils/contractreflectioninterface.h
@@ -21,12 +21,110 @@ See the LICENSE.txt file in the project root for more information.
  * TODO: Add support for overloaded methods! This will require a change in the mappings and templates...
  */
 namespace ContractReflectionInterface {
+  /**
+   * Unique identifier for a pointer to member function.
+   * This is used to derive the name of a function from a pointer to member function.
+   * TODO: Not sure if this is undefined behavior or not, but it works, except for when using a function pointer to a function in a base class.
+   * If the derived class didn't re-register the function, it will not be found in the map.
+   * You will need to use the base class instead of the derived class.
+   */
+  class UniqueFunctionPointerIdentifier {
+  private:
+    std::string returnType;
+    std::string className;
+    uint64_t ptr1 = 0;
+    uint64_t ptr2 = 0;
+  public:
+    /// Specialization for non-const functions without args.
+    template <typename TContract, typename R>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)()) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    /// Specialization for const functions without args.
+    template <typename TContract, typename R>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)() const) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    /// Specialization for non-const functions with non-const args.
+    template <typename TContract, typename R, typename... Args>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)(Args...)) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    /// Specialization for const functions with non-const args.
+    template <typename TContract, typename R, typename... Args>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)(Args...) const) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    /// Specialization for non-const functions with const args.
+    template <typename TContract, typename R, typename... Args>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)(const Args&...)) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    /// Specialization for const functions with const args.
+    template <typename TContract, typename R, typename... Args>
+    UniqueFunctionPointerIdentifier(R(TContract::*func)(const Args&...) const) {
+      this->returnType = Utils::getRealTypeName<R>();
+      this->className = Utils::getRealTypeName<TContract>();
+      /// Check if sizeof func is sizeof(uint64_t) * 2
+      static_assert(sizeof(func) == sizeof(uint64_t) * 2, "Function pointer size is not 16 bytes");
+      /// Copy the function pointer into the two uint64_t
+      memcpy(&ptr1, &func, sizeof(uint64_t));
+      memcpy(&ptr2, ((uint64_t*)&func) + 1, sizeof(uint64_t));
+    }
+
+    bool operator==(const UniqueFunctionPointerIdentifier& other) const {
+      return ptr1 == other.ptr1 && ptr2 == other.ptr2 && className == other.className && returnType == other.returnType;
+    }
+
+    struct Hash {
+      std::size_t operator()(const UniqueFunctionPointerIdentifier& fpw) const {
+        return std::hash<uint64_t>{}(fpw.ptr1) ^ std::hash<uint64_t>{}(fpw.ptr2) ^ std::hash<std::string>{}(fpw.className) ^ std::hash<std::string>{}(fpw.returnType);
+      }
+    };
+  };
+
   // All declared in the cpp file.
   extern std::unordered_map<std::string, bool> registeredContractsFunctionsMap;
   extern std::unordered_map<std::string, bool> registeredContractsEventsMap;
   extern std::unordered_map<std::string, std::vector<std::string>> ctorArgNamesMap;
   extern std::unordered_map<std::string, std::unordered_multimap<std::string, ABI::MethodDescription>> methodDescsMap;
   extern std::unordered_map<std::string, std::unordered_multimap<std::string, ABI::EventDescription>> eventDescsMap;
+  extern std::unordered_map<UniqueFunctionPointerIdentifier, std::string, UniqueFunctionPointerIdentifier::Hash> pointerNamesMap;
 
   /**
    * Helper struct to extract arguments from a function pointer.
@@ -58,6 +156,10 @@ namespace ContractReflectionInterface {
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
     }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)()) {
+      return UniqueFunctionPointerIdentifier(func);
+    }
   };
 
   /**
@@ -74,6 +176,10 @@ namespace ContractReflectionInterface {
     /// Get the function return types.
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
+    }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)() const) {
+      return UniqueFunctionPointerIdentifier(func);
     }
   };
 
@@ -95,6 +201,10 @@ namespace ContractReflectionInterface {
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
     }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)(Args...)) {
+      return UniqueFunctionPointerIdentifier(func);
+    }
   };
 
   /**
@@ -114,6 +224,10 @@ namespace ContractReflectionInterface {
     /// Get the function return types.
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
+    }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)(Args...) const) {
+      return UniqueFunctionPointerIdentifier(func);
     }
   };
 
@@ -135,6 +249,10 @@ namespace ContractReflectionInterface {
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
     }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)(const Args&...)) {
+      return UniqueFunctionPointerIdentifier(func);
+    }
   };
 
   /**
@@ -155,6 +273,10 @@ namespace ContractReflectionInterface {
     static std::vector<std::string> getFunctionReturnTypes() {
       return ABI::FunctorEncoder::listArgumentTypesV<R>();
     }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(R(TContract::*func)(const Args&...) const) {
+      return UniqueFunctionPointerIdentifier(func);
+    }
   };
 
 
@@ -169,6 +291,10 @@ namespace ContractReflectionInterface {
     static std::vector<std::pair<std::string, bool>> getArgs() {
       return ABI::FunctorEncoder::listEventTypesV<EventParam<Args, Flags>...>::get();
     }
+    /// Get UniqueFunctionPointerIdentifier
+    static UniqueFunctionPointerIdentifier getUniqueFunctionPointerIdentifier(void(TContract::*func)(const EventParam<Args, Flags>&...)) {
+      return UniqueFunctionPointerIdentifier(func);
+    }
   };
 
   /**
@@ -176,6 +302,7 @@ namespace ContractReflectionInterface {
    * @tparam TContract The contract type.
    * @param name The method's name.
    * @param mut The method's mutability.
+   * @param func The unique function pointer identifier.
    * @param args The method's arguments.
    * @param argsNames The method's argument names.
    * @param rets The method's return types.
@@ -183,6 +310,7 @@ namespace ContractReflectionInterface {
   template <typename TContract> void inline populateMethodTypesMap(
     const std::string& name,
     const FunctionTypes& mut,
+    const UniqueFunctionPointerIdentifier& func,
     const std::vector<std::string>& args,
     const std::vector<std::string>& argsNames,
     const std::vector<std::string>& rets
@@ -199,14 +327,21 @@ namespace ContractReflectionInterface {
     desc.stateMutability = mut;
     desc.type = "function";
     methodDescsMap[Utils::getRealTypeName<TContract>()].insert(std::make_pair(name, desc));
+    pointerNamesMap[func] = name;
   }
 
   /**
    * Populate the event argument names map.
+   * @param name The event's name.
+   * @param anonymous Whether the event is anonymous or not.
+   * @param func The unique function pointer identifier.
+   * @param args The event's arguments.
+   * @param argsNames The event's argument names.
    */
   template <typename TContract> void inline populateEventTypesMap(
     const std::string& name,
     bool anonymous,
+    const UniqueFunctionPointerIdentifier& func,
     std::vector<std::pair<std::string, bool>> args,
     std::vector<std::string> argsNames
   ) {
@@ -264,6 +399,7 @@ namespace ContractReflectionInterface {
     ((populateMethodTypesMap<TContract>(
       std::get<0>(methods),
       std::get<2>(methods),
+      populateMethodTypesMapHelper<std::decay_t<decltype(std::get<1>(methods))>>::getUniqueFunctionPointerIdentifier(std::get<1>(methods)),
       populateMethodTypesMapHelper<std::decay_t<decltype(std::get<1>(methods))>>::getFunctionArgs(),
       std::get<3>(methods),
       populateMethodTypesMapHelper<std::decay_t<decltype(std::get<1>(methods))>>::getFunctionReturnTypes()
@@ -285,6 +421,7 @@ namespace ContractReflectionInterface {
     ((populateEventTypesMap<TContract>(
       std::get<0>(events),
       std::get<1>(events),
+      populateEventTypesMapHelper<std::decay_t<decltype(std::get<2>(events))>>::getUniqueFunctionPointerIdentifier(std::get<2>(events)),
       populateEventTypesMapHelper<std::decay_t<decltype(std::get<2>(events))>>::getArgs(),
       std::get<3>(events)
     )), ...);
@@ -366,6 +503,82 @@ namespace ContractReflectionInterface {
       descriptions.push_back(desc);
     }
     return descriptions;
+  }
+
+  /**
+   * Get a function name from a pointer to member function.
+   * Specialization for non-const functions without args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @param func The pointer to member function.
+   */
+  template <typename TContract, typename R>
+  std::string inline getFunctionName(R(TContract::*func)()) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
+  }
+
+  /**
+   * Get a function name from a pointer to member function
+   * Specialization for const functions without args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @param func The pointer to member function.
+   */
+  template <typename TContract, typename R>
+  std::string inline getFunctionName(R(TContract::*func)() const) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
+  }
+
+  /**
+   * Get a function name from a pointer to member function
+   * Specialization for non-const functions with non-const args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @tparam Args The argument types.
+   * @param func The pointer to member function.
+   */
+  template <typename TContract, typename R, typename... Args>
+  std::string inline getFunctionName(R(TContract::*func)(Args...)) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
+  }
+
+  /**
+   * Get a function name from a pointer to member function
+   * Specialization for const functions with non-const args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @tparam Args The argument types.
+   * @param func The pointer to member function.
+   */
+  template<typename TContract, typename R, typename... Args>
+  std::string inline getFunctionName(R(TContract::*func)(Args...) const) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
+  }
+
+  /**
+   * Get a function name from a pointer to member function
+   * Specialization for non-const functions with const args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @tparam Args The argument types.
+   * @param func The pointer to member function.
+   */
+  template <typename TContract, typename R, typename... Args>
+  std::string inline getFunctionName(R(TContract::*func)(const Args&...)) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
+  }
+
+  /**
+   * Get a function name from a pointer to member function
+   * Specialization for const functions with const args.
+   * @tparam TContract The contract type.
+   * @tparam R The return type.
+   * @tparam Args The argument types.
+   * @param func The pointer to member function.
+   */
+  template <typename TContract, typename R, typename... Args>
+  std::string inline getFunctionName(R(TContract::*func)(const Args&...) const) {
+    return pointerNamesMap[UniqueFunctionPointerIdentifier(func)];
   }
 } // namespace ContractReflectionInterface
 

--- a/src/utils/contractreflectioninterface.h
+++ b/src/utils/contractreflectioninterface.h
@@ -257,7 +257,7 @@ namespace ContractReflectionInterface {
    * @param methods The methods to register.
    */
   template <typename TContract, typename... Args, typename... Methods>
-  void inline registerContract(const std::vector<std::string>& ctorArgs, Methods&&... methods) {
+  void inline registerContractMethods(const std::vector<std::string>& ctorArgs, Methods&&... methods) {
     if (isContractFunctionsRegistered<TContract>()) return; // Skip if contract is already registered
     ctorArgNamesMap[Utils::getRealTypeName<TContract>()] = ctorArgs; // Store ctor arg names in ctorArgNamesMap
     // Register the methods

--- a/src/utils/contractreflectioninterface.h
+++ b/src/utils/contractreflectioninterface.h
@@ -24,9 +24,7 @@ namespace ContractReflectionInterface {
   /**
    * Unique identifier for a pointer to member function.
    * This is used to derive the name of a function from a pointer to member function.
-   * TODO: Not sure if this is undefined behavior or not, but it works, except for when using a function pointer to a function in a base class.
-   * If the derived class didn't re-register the function, it will not be found in the map.
-   * You will need to use the base class instead of the derived class.
+   * TODO: Not sure if this is undefined behavior or not, but it works
    */
   class UniqueFunctionPointerIdentifier {
   private:
@@ -357,6 +355,7 @@ namespace ContractReflectionInterface {
       desc.args.push_back(argDesc);
     }
     eventDescsMap[Utils::getRealTypeName<TContract>()].insert(std::make_pair(name, desc));
+    pointerNamesMap[func] = name;
   }
 
 

--- a/src/utils/db.h
+++ b/src/utils/db.h
@@ -104,8 +104,10 @@ class DBBatch {
       tmp.reserve(prefix.size() + key.size());
       tmp.insert(tmp.end(), key.begin(), key.end());
       puts_.emplace_back(std::move(tmp), Bytes(value.begin(), value.end()));
-      putsSlices_.emplace_back(rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().key.data()), puts_.back().key.size()),
-                              rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().value.data()), puts_.back().value.size()));
+      putsSlices_.emplace_back(
+        rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().key.data()), puts_.back().key.size()),
+        rocksdb::Slice(reinterpret_cast<const char*>(puts_.back().value.data()), puts_.back().value.size())
+      );
     }
 
     /**
@@ -118,7 +120,9 @@ class DBBatch {
       tmp.reserve(prefix.size() + key.size());
       tmp.insert(tmp.end(), key.begin(), key.end());
       dels_.emplace_back(std::move(tmp));
-      delsSlices_.emplace_back(rocksdb::Slice(reinterpret_cast<const char*>(dels_.back().data()), dels_.back().size()));
+      delsSlices_.emplace_back(
+        rocksdb::Slice(reinterpret_cast<const char*>(dels_.back().data()), dels_.back().size())
+      );
     }
 
     /**
@@ -155,7 +159,6 @@ class DB {
     rocksdb::DB* db_;              ///< Pointer to the database object itself.
     rocksdb::Options opts_;        ///< Struct with options for managing the database.
     mutable std::mutex batchLock_; ///< Mutex for managing read/write access to batch operations.
-    // TODO: add a custom comparator for more granular key comparisons (e.g. for events)
 
   public:
     /**
@@ -291,6 +294,7 @@ class DB {
      * Get all keys from a given prefix.
      * Ranges can be used to mitigate very expensive operations
      * (e.g. a query can return millions of entries).
+     * Prefix is automatically added to the queries themselves internally.
      * @param pfx The prefix to search keys from.
      * @param start (optional) The first key to start searching from.
      * @param end (optional) The last key to end searching at.

--- a/src/utils/db.h
+++ b/src/utils/db.h
@@ -155,6 +155,7 @@ class DB {
     rocksdb::DB* db_;              ///< Pointer to the database object itself.
     rocksdb::Options opts_;        ///< Struct with options for managing the database.
     mutable std::mutex batchLock_; ///< Mutex for managing read/write access to batch operations.
+    // TODO: add a custom comparator for more granular key comparisons (e.g. for events)
 
   public:
     /**
@@ -288,19 +289,21 @@ class DB {
 
     /**
      * Get all keys from a given prefix.
-     * @param pfx (optional) The prefix to search keys from. Defaults to an empty string.
+     * Ranges can be used to mitigate very expensive operations
+     * (e.g. a query can return millions of entries).
+     * @param pfx The prefix to search keys from.
+     * @param start (optional) The first key to start searching from.
+     * @param end (optional) The last key to end searching at.
      * @return A list of found keys, WITHOUT their prefixes.
      */
-    std::vector<Bytes> getKeys(const Bytes& pfx = {});
+    std::vector<Bytes> getKeys(const Bytes& pfx, const Bytes& start = {}, const Bytes& end = {});
 
     /**
      * Create a Bytes container from a string.
      * @param str The string to convert.
      * @return The Bytes container.
      */
-    inline static Bytes keyFromStr(const std::string str) {
-      return Bytes(str.begin(), str.end());
-    }
+    inline static Bytes keyFromStr(const std::string str) { return Bytes(str.begin(), str.end()); }
 };
 
 #endif // DB_H

--- a/src/utils/jsonabi.cpp
+++ b/src/utils/jsonabi.cpp
@@ -41,11 +41,11 @@ std::vector<std::string> JsonAbi::getTupleTypes(const std::string& type) {
   );
   tupleString = tupleString.substr(0, tupleString.size() - 1); // Remove ")"
   std::string tmp;
-  bool inTuple = false; // We need to check if we're inside a tuple, so we don't split on "," inside "(...)".
+  uint16_t tupleCounter = 0; // We need to check if we're inside a tuple, so we don't split on "," inside "(...)".
   for (const char& c : tupleString) {
-    if (c == '(') inTuple = true;
-    if (c == ')') inTuple = false;
-    if (c == ',' && !inTuple) {
+    if (c == '(') ++tupleCounter;
+    if (c == ')') --tupleCounter;
+    if (c == ',' && !tupleCounter) {
       types.push_back(tmp);
       tmp = "";
     } else {

--- a/src/utils/jsonabi.cpp
+++ b/src/utils/jsonabi.cpp
@@ -40,7 +40,20 @@ std::vector<std::string> JsonAbi::getTupleTypes(const std::string& type) {
     0, tupleString.size() - 2 * JsonAbi::countTupleArrays(type) // If array, delete "[]"
   );
   tupleString = tupleString.substr(0, tupleString.size() - 1); // Remove ")"
-  boost::split(types, tupleString, [](char c) { return c == ','; }); // Split by commas
+  std::string tmp;
+  bool inTuple = false; // We need to check if we're inside a tuple, so we don't split on "," inside "(...)".
+  for (const char& c : tupleString) {
+    if (c == '(') inTuple = true;
+    if (c == ')') inTuple = false;
+    if (c == ',' && !inTuple) {
+      types.push_back(tmp);
+      tmp = "";
+    } else {
+      tmp += c;
+    }
+  }
+  /// Push the last type.
+  types.push_back(tmp);
   return types;
 }
 

--- a/src/utils/options.h.in
+++ b/src/utils/options.h.in
@@ -7,6 +7,8 @@
 #include <filesystem>
 #include <boost/asio/ip/address.hpp>
 
+// TODO: move blockCap and logCap from EventManager here
+
 /// Singleton class for global node data.
 class Options {
   private:

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -348,6 +348,36 @@ namespace Utils {
   template <typename... Ts>
   struct is_tuple<std::tuple<Ts...>> : std::true_type {};
 
+  // Helper struct to conditionally append a type to a tuple
+    template <bool Flag, typename T, typename Tuple>
+    struct conditional_tuple_append {
+        using type = Tuple;
+    };
+
+    template <typename T, typename... Ts>
+    struct conditional_tuple_append<false, T, std::tuple<Ts...>> {
+        using type = std::tuple<Ts..., T>;
+    };
+
+    template<typename Accumulated, typename... Rest>
+    struct makeTupleTypeHelper {
+        using type = Accumulated;
+    };
+
+    template<typename Accumulated, typename T, bool Flag, typename... Rest>
+    struct makeTupleTypeHelper<Accumulated, EventParam<T, Flag>, Rest...> {
+        using NextAccumulated = typename conditional_tuple_append<Flag, T, Accumulated>::type;
+        using type = typename makeTupleTypeHelper<NextAccumulated, Rest...>::type;
+    };
+
+    template<typename... Args>
+    struct makeTupleType;
+
+    template<typename... Args, bool... Flags>
+    struct makeTupleType<EventParam<Args, Flags>...> {
+        using type = typename makeTupleTypeHelper<std::tuple<>, EventParam<Args, Flags>...>::type;
+    };
+
   extern std::atomic<bool> logToCout; ///< Indicates whether logging to stdout is allowed (for safePrint()).
 
   /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TESTS_HEADERS
   ""
+  ${CMAKE_SOURCE_DIR}/tests/sdktestsuite.hpp
   PARENT_SCOPE
 )
 
@@ -41,6 +42,7 @@ set (TESTS_SOURCES
   # ${CMAKE_SOURCE_DIR}/tests/core/blockchain.cpp # TODO: Blockchain is failing due to rdPoSWorker.
   ${CMAKE_SOURCE_DIR}/tests/net/p2p/p2p.cpp
   ${CMAKE_SOURCE_DIR}/tests/net/http/httpjsonrpc.cpp
+  ${CMAKE_SOURCE_DIR}/tests/sdktestsuite.cpp
   PARENT_SCOPE
 )
 

--- a/tests/contract/contractabigenerator.cpp
+++ b/tests/contract/contractabigenerator.cpp
@@ -157,4 +157,11 @@ TEST_CASE("ContractABIGenerator helper", "[contract][contractabigenerator]") {
     auto findNameChanged = std::find(j.begin(), j.end(), EXPECTED::SimpleContract::nameChanged);
     REQUIRE(findNameChanged != j.end());
   }
+
+  SECTION("ContractABIGenerator getFunctionName") {
+    REQUIRE(ContractReflectionInterface::getFunctionName(&NativeWrapper::deposit) == "deposit");
+    REQUIRE(ContractReflectionInterface::getFunctionName(&NativeWrapper::withdraw) == "withdraw");
+    REQUIRE(ContractReflectionInterface::getFunctionName(&NativeWrapper::transfer) == "transfer");
+    REQUIRE(ContractReflectionInterface::getFunctionName(&ERC20::transfer) == "transfer");
+  }
 }

--- a/tests/contract/contractmanager.cpp
+++ b/tests/contract/contractmanager.cpp
@@ -14,8 +14,14 @@ See the LICENSE.txt file in the project root for more information.
 #include <filesystem>
 #include <sys/types.h>
 
-// Forward declaration.
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
+ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall) {
+  ethCallInfoAllocated callInfo;
+  auto& [from, to, gasLimit, gasPrice, value, functor, data] = callInfo;
+  to = addressToCall;
+  functor = function;
+  data = dataToCall;
+  return callInfo;
+}
 
 namespace TContractManager {
   std::string testDumpPath = Utils::getTestDumpPath();

--- a/tests/contract/dexv2.cpp
+++ b/tests/contract/dexv2.cpp
@@ -10,411 +10,119 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/contract/templates/dexv2/dexv2pair.h"
 #include "../../src/contract/templates/dexv2/dexv2factory.h"
 #include "../../src/contract/templates/dexv2/dexv2router02.h"
+#include "../../src/contract/templates/nativewrapper.h"
 #include "../../src/contract/abi.h"
 #include "../../src/utils/db.h"
 #include "../../src/utils/options.h"
 #include "../../src/core/rdpos.h"
 #include "../../src/core/state.h"
+
+#include "../sdktestsuite.hpp"
+
 #include <utility>
 
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
-
-void initialize(std::unique_ptr<DB>& db,
-                std::unique_ptr<Storage>& storage,
-                std::unique_ptr<P2P::ManagerNormal>& p2p,
-                std::unique_ptr<rdPoS>& rdpos,
-                std::unique_ptr<State>& state,
-                std::unique_ptr<Options>& options,
-                PrivKey validatorKey,
-                uint64_t serverPort,
-                bool clearDb,
-                std::string folderName);
-
-Block createValidBlock(std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, const std::vector<TxBlock>& txs = {});
-
-const std::vector<Hash> validatorPrivKeys {
-    Hash(Hex::toBytes("0x0a0415d68a5ec2df57aab65efc2a7231b59b029bae7ff1bd2e40df9af96418c8")),
-    Hash(Hex::toBytes("0xb254f12b4ca3f0120f305cabf1188fe74f0bd38e58c932a3df79c4c55df8fa66")),
-    Hash(Hex::toBytes("0x8a52bb289198f0bcf141688a8a899bf1f04a02b003a8b1aa3672b193ce7930da")),
-    Hash(Hex::toBytes("0x9048f5e80549e244b7899e85a4ef69512d7d68613a3dba828266736a580e7745")),
-    Hash(Hex::toBytes("0x0b6f5ad26f6eb79116da8c98bed5f3ed12c020611777d4de94c3c23b9a03f739")),
-    Hash(Hex::toBytes("0xa69eb3a3a679e7e4f6a49fb183fb2819b7ab62f41c341e2e2cc6288ee22fbdc7")),
-    Hash(Hex::toBytes("0xd9b0613b7e4ccdb0f3a5ab0956edeb210d678db306ab6fae1e2b0c9ebca1c2c5")),
-    Hash(Hex::toBytes("0x426dc06373b694d8804d634a0fd133be18e4e9bcbdde099fce0ccf3cb965492f"))
-};
-
-/// Create a new transaction based on to, value, function (with arguments) and arguments...
-template <typename... Args>
-TxBlock createNewTransaction(const PrivKey& privKey,
-                             const Address& to,
-                             const uint256_t& value,
-                             const std::unique_ptr<State>& state,
-                             const std::unique_ptr<Options>& options,
-                             const Bytes& functor,
-                             Args&&... args) {
-  Bytes encoder = ABI::Encoder::encodeData(std::forward<Args>(args)...);
-
-  Bytes txData = functor;
-  Utils::appendBytes(txData, encoder);
-
-  Address from = Secp256k1::toAddress(Secp256k1::toUPub(privKey));
-
-  TxBlock tx(to,
-             from,
-             txData,
-             options->getChainID(),
-             state->getNativeNonce(from),
-             value,
-             1000000000, // 1 GWEI
-             1000000000, // 1 GWEI
-             21000,
-             privKey);
-
-  return tx;
-}
-
-Address createNewERC20(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, std::unique_ptr<Options>& options,
-                       const std::string& tokenName, const std::string& tokenSymbol, uint8_t decimals, const uint256_t& mintValue) {
-  PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-  auto createNewERC20Tx = createNewTransaction(
-    chainOwnerPrivKey,
-    ProtocolContractAddresses.at("ContractManager"),
-    uint256_t(0),
-    state,
-    options,
-    Hex::toBytes("0xb74e5ed5"),
-    tokenName,
-    tokenSymbol,
-    static_cast<uint256_t>(decimals),
-    mintValue
-  );
-  auto prevContractList = state->getContracts();
-
-  auto newBlock = createValidBlock(rdpos, storage, {createNewERC20Tx});
-
-  if (!state->validateNextBlock(newBlock)) {
-    throw std::runtime_error("createNewERC20: Failed to validate block");
-  }
-
-  try {
-    state->processNextBlock(std::move(newBlock));
-  } catch (std::exception &e) {
-    throw std::runtime_error("createNewERC20: Failed to process block: " + std::string(e.what()));
-  }
-
-  auto newContractList = state->getContracts();
-  Address newContractAddress;
-  /// Find the new contract address
-  for (const auto& contract : newContractList) {
-    if (std::find(prevContractList.begin(), prevContractList.end(), contract) == prevContractList.end()) {
-      newContractAddress = contract.second;
-      break;
-    }
-  }
-  return newContractAddress;
-}
-
-Address createNewFactory(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, std::unique_ptr<Options>& options,
-                         const Address& feeToSetter) {
-  PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-  auto createNewFactoryTx = createNewTransaction(
-    chainOwnerPrivKey,
-    ProtocolContractAddresses.at("ContractManager"),
-    uint256_t(0),
-    state,
-    options,
-    Hex::toBytes("0xf02da5d2"),
-    feeToSetter
-  );
-
-  auto prevContractList = state->getContracts();
-
-  auto newBlock = createValidBlock(rdpos, storage, {createNewFactoryTx});
-
-  if (!state->validateNextBlock(newBlock)) {
-    throw std::runtime_error("createNewERC20: Failed to validate block");
-  }
-
-  try {
-    state->processNextBlock(std::move(newBlock));
-  } catch (std::exception &e) {
-    throw std::runtime_error("createNewERC20: Failed to process block: " + std::string(e.what()));
-  }
-
-  auto newContractList = state->getContracts();
-  Address newContractAddress;
-  /// Find the new contract address
-  for (const auto& contract : newContractList) {
-    if (std::find(prevContractList.begin(), prevContractList.end(), contract) == prevContractList.end()) {
-      newContractAddress = contract.second;
-      break;
-    }
-  }
-  return newContractAddress;
-
-}
-
-Address createNewRouter(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, std::unique_ptr<Options>& options,
-                        const Address& factory, const Address& nativeWrapper) {
-  PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-  auto createNewRouterTx = createNewTransaction(
-    chainOwnerPrivKey,
-    ProtocolContractAddresses.at("ContractManager"),
-    uint256_t(0),
-    state,
-    options,
-    Hex::toBytes("0x5d0ba0d6"),
-    factory,
-    nativeWrapper
-  );
-
-  auto prevContractList = state->getContracts();
-
-  auto newBlock = createValidBlock(rdpos, storage, {createNewRouterTx});
-
-  if (!state->validateNextBlock(newBlock)) {
-    throw std::runtime_error("createNewERC20: Failed to validate block");
-  }
-
-  try {
-    state->processNextBlock(std::move(newBlock));
-  } catch (std::exception &e) {
-    throw std::runtime_error("createNewERC20: Failed to process block: " + std::string(e.what()));
-  }
-
-  auto newContractList = state->getContracts();
-  Address newContractAddress;
-  /// Find the new contract address
-  for (const auto& contract : newContractList) {
-    if (std::find(prevContractList.begin(), prevContractList.end(), contract) == prevContractList.end()) {
-      newContractAddress = contract.second;
-      break;
-    }
-  }
-  return newContractAddress;
-}
-
-Address createNewNative(std::unique_ptr<State>& state, std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, std::unique_ptr<Options>& options,
-                        const std::string& tokenName, const std::string& tokenSymbol, uint8_t tokenDecimal) {
-  PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-  auto createNewNativeTx = createNewTransaction(
-    chainOwnerPrivKey,
-    ProtocolContractAddresses.at("ContractManager"),
-    uint256_t(0),
-    state,
-    options,
-    Hex::toBytes("0xb296fad4"),
-    tokenName,
-    tokenSymbol,
-    static_cast<uint256_t>(tokenDecimal)
-  );
-
-  auto prevContractList = state->getContracts();
-
-  auto newBlock = createValidBlock(rdpos, storage, {createNewNativeTx});
-
-  if (!state->validateNextBlock(newBlock)) {
-    throw std::runtime_error("createNewERC20: Failed to validate block");
-  }
-
-  try {
-    state->processNextBlock(std::move(newBlock));
-  } catch (std::exception &e) {
-    throw std::runtime_error("createNewERC20: Failed to process block: " + std::string(e.what()));
-  }
-
-  auto newContractList = state->getContracts();
-  Address newContractAddress;
-  /// Find the new contract address
-  for (const auto& contract : newContractList) {
-    if (std::find(prevContractList.begin(), prevContractList.end(), contract) == prevContractList.end()) {
-      newContractAddress = contract.second;
-      break;
-    }
-  }
-  return newContractAddress;
-}
-
-TxBlock createApproveTx(std::unique_ptr<State>& state, std::unique_ptr<Options>& options, const PrivKey& privKey, const Address& erc20, const Address& spender, const uint256_t& value) {
-  auto approveTx = createNewTransaction(
-    privKey,
-    erc20,
-    uint256_t(0),
-    state,
-    options,
-    Hex::toBytes("0x095ea7b3"),
-    spender,
-    value
-  );
-  return approveTx;
-}
+// TODO: test events if/when implemented
 
 namespace TDEXV2 {
-  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("DEXV2 Test", "[contract][dexv2]") {
     SECTION("Deploy DEXV2Router/Factory with a single pair") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address factory;
-      Address router;
-      Address wrapped;
-
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/DEXV2NewContractsTest");
-        wrapped = createNewNative(state, rdpos, storage, options, "WSPARQ", "WSPARQ", 18);
-        factory = createNewFactory(state, rdpos, storage, options, Address());
-        router = createNewRouter(state, rdpos, storage, options, factory, wrapped);
-      }
-
-      std::unique_ptr<DB> db;
-      std::unique_ptr<Storage> storage;
-      std::unique_ptr<P2P::ManagerNormal> p2p;
-      std::unique_ptr<rdPoS> rdpos;
-      std::unique_ptr<State> state;
-      std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false, testDumpPath + "/DEXV2NewContractsTest");
-
-      auto contracts = state->getContracts();
-      for (const auto& contract : contracts) {
+      SDKTestSuite sdk("testDEXV2SinglePair");
+      Address wrapped = sdk.deployContract<NativeWrapper>(std::string("WSPARQ"), std::string("WSPARQ"), uint8_t(18));
+      Address factory = sdk.deployContract<DEXV2Factory>(Address());
+      Address router = sdk.deployContract<DEXV2Router02>(factory, wrapped);
+      Address owner = sdk.getChainOwnerAccount().address;
+      for (const auto& contract : sdk.getState()->getContracts()) {
+        if (contract.first == "NativeWrapper") REQUIRE(contract.second == wrapped);
         if (contract.first == "DEXV2Factory")  REQUIRE(contract.second == factory);
         if (contract.first == "DEXV2Router02") REQUIRE(contract.second == router);
-        if (contract.first == "NativeWrapper") REQUIRE(contract.second == wrapped);
       }
     }
 
     SECTION("Deploy DEXV2 and add liquidity to token/token pair") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address factory;
-      Address router;
-      Address wrapped;
-      Address tokenA;
-      Address tokenB;
-
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/DEXV2NewContractsTest");
-
-        wrapped = createNewNative(state, rdpos, storage, options, "WSPARQ", "WSPARQ", 18);
-        factory = createNewFactory(state, rdpos, storage, options, Address());
-        router = createNewRouter(state, rdpos, storage, options, factory, wrapped);
-        tokenA = createNewERC20(
-          state, rdpos, storage, options,
-          "TokenA", "TKNA", 18, uint256_t("10000000000000000000000")
-        );
-        tokenB = createNewERC20(
-          state, rdpos, storage, options,
-          "tokenB", "TKNB", 18, uint256_t("10000000000000000000000")
-        );
-
-        auto approveATx = createApproveTx(
-          state, options, ownerPrivKey, tokenA, router, uint256_t("10000000000000000000000")
-        );
-        auto approveBTx = createApproveTx(
-          state, options, ownerPrivKey, tokenB, router, uint256_t("10000000000000000000000")
-        );
-
-        auto newBlock = createValidBlock(rdpos, storage, {approveATx, approveBTx});
-        REQUIRE(state->validateNextBlock(newBlock));
-        state->processNextBlock(std::move(newBlock));
-
-        uint256_t unixtimestamp = std::chrono::duration_cast<std::chrono::seconds>(
-          std::chrono::system_clock::now().time_since_epoch()
-        ).count() + 600;
-
-        auto addLiquidityTx = createNewTransaction(
-          ownerPrivKey,
-          router,
-          uint256_t(0),
-          state,
-          options,
-          Hex::toBytes("0xe8e33700"),
-          tokenA,                                                       // tokenA
-          tokenB,                                                       // tokenB
-          uint256_t("100000000000000000000"),                           // amountADesired
-          uint256_t("250000000000000000000"),                           // amountBDesired
-          uint256_t(0),                                                            // amountAMin
-          uint256_t(0),                                                          // amountBMin
-          Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),        // to
-          unixtimestamp                                                 // deadline
-        );
-
-        auto newBlock2 = createValidBlock(rdpos, storage, {addLiquidityTx});
-        REQUIRE(state->validateNextBlock(newBlock2));
-        state->processNextBlock(std::move(newBlock2));
+      SDKTestSuite sdk("testDEXV2LiqTokenTokenPair");
+      Address tokenA = sdk.deployContract<ERC20>(std::string("TokenA"), std::string("TKNA"), uint8_t(18), uint256_t("10000000000000000000000"));
+      Address tokenB = sdk.deployContract<ERC20>(std::string("TokenB"), std::string("TKNB"), uint8_t(18), uint256_t("10000000000000000000000"));
+      Address wrapped = sdk.deployContract<NativeWrapper>(std::string("WSPARQ"), std::string("WSPARQ"), uint8_t(18));
+      Address factory = sdk.deployContract<DEXV2Factory>(Address());
+      Address router = sdk.deployContract<DEXV2Router02>(factory, wrapped);
+      Address owner = sdk.getChainOwnerAccount().address;
+      for (const auto& contract : sdk.getState()->getContracts()) {
+        if (contract.first == "NativeWrapper") REQUIRE(contract.second == wrapped);
+        if (contract.first == "DEXV2Factory")  REQUIRE(contract.second == factory);
+        if (contract.first == "DEXV2Router02") REQUIRE(contract.second == router);
       }
+
+      // Approve "router" so it can spend up to 10000 tokens from both sides
+      // on behalf of "owner" (which already has the tokens)
+      Hash approveATx = sdk.callFunction(tokenA, &ERC20::approve, router, uint256_t("10000000000000000000000"));
+      Hash approveBTx = sdk.callFunction(tokenB, &ERC20::approve, router, uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenA, &ERC20::allowance, owner, router) == uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenB, &ERC20::allowance, owner, router) == uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenA, &ERC20::balanceOf, owner) == uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenB, &ERC20::balanceOf, owner) == uint256_t("10000000000000000000000"));
+
+      // Add liquidity of 100 from A and 250 from B
+      uint256_t deadline = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+      ).count() + 60000000;  // 60 seconds
+      // tokenA, tokenB, amountADesired, amountBDesired, amountAMin, amountBMin, to, deadline
+      Hash addLiqudityTx = sdk.callFunction(router, &DEXV2Router02::addLiquidity,
+        tokenA, tokenB, uint256_t("100000000000000000000"), uint256_t("250000000000000000000"),
+        uint256_t(0), uint256_t(0), owner, deadline
+      );
+
+      // Check if operation worked sucessfully
+      Address pair = sdk.callViewFunction(factory, &DEXV2Factory::getPair, tokenA, tokenB);
+      uint256_t ownerTknA = sdk.callViewFunction(tokenA, &ERC20::balanceOf, owner);
+      uint256_t ownerTknB = sdk.callViewFunction(tokenB, &ERC20::balanceOf, owner);
+      uint256_t pairTknA = sdk.callViewFunction(tokenA, &ERC20::balanceOf, pair);
+      uint256_t pairTknB = sdk.callViewFunction(tokenB, &ERC20::balanceOf, pair);
+      REQUIRE(ownerTknA == uint256_t("9900000000000000000000"));
+      REQUIRE(ownerTknB == uint256_t("9750000000000000000000"));
+      REQUIRE(pairTknA == uint256_t("100000000000000000000"));
+      REQUIRE(pairTknB == uint256_t("250000000000000000000"));
     }
 
     SECTION("Deploy DEXV2 and add liquidity to token/native pair") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address factory;
-      Address router;
-      Address wrapped;
-      Address tokenA;
-
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true, testDumpPath + "/DEXV2NewContractsTest");
-
-        wrapped = createNewNative(state, rdpos, storage, options, "WSPARQ", "WSPARQ", 18);
-        factory = createNewFactory(state, rdpos, storage, options, Address());
-        router = createNewRouter(state, rdpos, storage, options, factory, wrapped);
-
-        tokenA = createNewERC20(
-          state, rdpos, storage, options,
-          "TokenA", "TKNA", 18, uint256_t("10000000000000000000000")
-        );
-
-        auto approveATx = createApproveTx(
-          state, options, ownerPrivKey, tokenA, router, uint256_t("10000000000000000000000")
-        );
-
-        auto newBlock = createValidBlock(rdpos, storage, {approveATx});
-        REQUIRE(state->validateNextBlock(newBlock));
-        state->processNextBlock(std::move(newBlock));
-
-        uint256_t unixtimestamp = std::chrono::duration_cast<std::chrono::seconds>(
-          std::chrono::system_clock::now().time_since_epoch()
-        ).count() + 600;
-
-        // addLiquidityNative(address token, uint256 amountTokenDesired, uint256 amountTokenMin, uint256 amountNativeMin, address to, uint256 deadline)
-        auto addLiquidityTx = createNewTransaction(
-          ownerPrivKey,
-          router,
-          uint256_t("100000000000000000000"),
-          state,
-          options,
-          Hex::toBytes("0xc9e164e3"),
-          tokenA,                                                       // Token
-          uint256_t("100000000000000000000"),                           // amountTokenDesired
-          uint256_t("100000000000000000000"),                           // amountTokenMin
-          uint256_t("100000000000000000000"),                           // amountNativeMin
-          Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),        // to
-          unixtimestamp                                                 // deadline
-        );
-
-        REQUIRE_THROWS(state->estimateGas(addLiquidityTx.txToCallInfo()));
-        auto newBlock2 = createValidBlock(rdpos, storage, {addLiquidityTx});
-        REQUIRE(state->validateNextBlock(newBlock2));
-        state->processNextBlock(std::move(newBlock2));
+      SDKTestSuite sdk("testDEXV2LiqTokenNativePair");
+      Address tokenA = sdk.deployContract<ERC20>(std::string("TokenA"), std::string("TKNA"), uint8_t(18), uint256_t("10000000000000000000000"));
+      Address wrapped = sdk.deployContract<NativeWrapper>(std::string("WSPARQ"), std::string("WSPARQ"), uint8_t(18));
+      Address factory = sdk.deployContract<DEXV2Factory>(Address());
+      Address router = sdk.deployContract<DEXV2Router02>(factory, wrapped);
+      Address owner = sdk.getChainOwnerAccount().address;
+      for (const auto& contract : sdk.getState()->getContracts()) {
+        if (contract.first == "NativeWrapper") REQUIRE(contract.second == wrapped);
+        if (contract.first == "DEXV2Factory")  REQUIRE(contract.second == factory);
+        if (contract.first == "DEXV2Router02") REQUIRE(contract.second == router);
       }
+
+      // Approve "router" so it can spend up to 10000 TKNA on behalf of "owner"
+      Hash approveATx = sdk.callFunction(tokenA, &ERC20::approve, router, uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenA, &ERC20::allowance, owner, router) == uint256_t("10000000000000000000000"));
+      REQUIRE(sdk.callViewFunction(tokenA, &ERC20::balanceOf, owner) == uint256_t("10000000000000000000000"));
+
+      // Add liquidity of 100 WSPARQ and 100 TKNA
+      uint256_t deadline = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+      ).count() + 60000000;  // 60 seconds
+      // token, amountTokenDesired, amountTokenMin, amountNativeMin, to, deadline
+      Hash addLiqudityTx = sdk.callFunction(
+        router, uint256_t("100000000000000000000"), &DEXV2Router02::addLiquidityNative,
+        tokenA, uint256_t("100000000000000000000"), uint256_t("100000000000000000000"),
+        uint256_t("100000000000000000000"), owner, deadline
+      );
+
+      // Check if operation worked successfully
+      // SDKTestSuite::createNewTx() is adding a tx fee of 21000 gwei, thus * 2
+      Address pair = sdk.callViewFunction(factory, &DEXV2Factory::getPair, tokenA, wrapped);
+      uint256_t ownerTknA = sdk.callViewFunction(tokenA, &ERC20::balanceOf, owner);
+      uint256_t ownerNative = sdk.getNativeBalance(owner);
+      uint256_t pairTknA = sdk.callViewFunction(tokenA, &ERC20::balanceOf, pair);
+      uint256_t pairNative = sdk.getNativeBalance(wrapped);
+      REQUIRE(ownerTknA == uint256_t("9900000000000000000000"));
+      REQUIRE(ownerNative == uint256_t("9900000000000000000000") - (uint256_t(1000000000) * 21000 * 2));
+      REQUIRE(pairTknA == uint256_t("100000000000000000000"));
+      REQUIRE(pairNative == uint256_t("100000000000000000000"));
     }
   }
 }

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -19,16 +19,6 @@ See the LICENSE.txt file in the project root for more information.
 
 // TODO: test events if/when implemented
 
-// TODO: remove this function, tests for ContractManager still depend on it
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall) {
-  ethCallInfoAllocated callInfo;
-  auto& [from, to, gasLimit, gasPrice, value, functor, data] = callInfo;
-  to = addressToCall;
-  functor = function;
-  data = dataToCall;
-  return callInfo;
-}
-
 namespace TERC20 {
   TEST_CASE("ERC2O Class", "[contract][erc20]") {
     SECTION("ERC20 creation") {

--- a/tests/contract/erc20.cpp
+++ b/tests/contract/erc20.cpp
@@ -13,8 +13,13 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/contract/contractmanager.h"
 #include "../../src/core/rdpos.h"
 
+#include "../sdktestsuite.hpp"
+
 #include <filesystem>
 
+// TODO: test events if/when implemented
+
+// TODO: remove this function, tests for ContractManager still depend on it
 ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall) {
   ethCallInfoAllocated callInfo;
   auto& [from, to, gasLimit, gasPrice, value, functor, data] = callInfo;
@@ -24,485 +29,96 @@ ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& 
   return callInfo;
 }
 
-
-void initialize(std::unique_ptr<Options>& options,
-                std::unique_ptr<DB>& db,
-                std::unique_ptr<ContractManager> &contractManager,
-                const std::string& dbName,
-                const PrivKey& ownerPrivKey,
-                const std::string& tokenName,
-                const std::string& tokenSymbol,
-                const uint8_t& tokenDecimals,
-                const uint256_t& tokenSupply,
-                bool deleteDB = true) {
-  if (deleteDB) {
-    if (std::filesystem::exists(dbName)) {
-      std::filesystem::remove_all(dbName);
-    }
-  }
-
-  options = std::make_unique<Options>(Options::fromFile(dbName));
-  db = std::make_unique<DB>(dbName);
-  std::unique_ptr<rdPoS> rdpos;
-  contractManager = std::make_unique<ContractManager>(nullptr, db, rdpos, options);
-
-  if (deleteDB) {
-    /// Create the contract.
-
-    Bytes createNewERC20ContractEncoder = ABI::Encoder::encodeData(tokenName, tokenSymbol, tokenDecimals, tokenSupply);
-    Bytes createNewERC20ContractData = Hex::toBytes("0xb74e5ed5");
-    Utils::appendBytes(createNewERC20ContractData, createNewERC20ContractEncoder);
-
-    TxBlock createNewERC2OTx = TxBlock(
-      ProtocolContractAddresses.at("ContractManager"),
-      Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-      createNewERC20ContractData,
-      8080,
-      0,
-      0,
-      0,
-      0,
-      0,
-      ownerPrivKey
-    );
-
-    contractManager->callContract(createNewERC2OTx);
-  }
-}
-
 namespace TERC20 {
-  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("ERC2O Class", "[contract][erc20]") {
-    PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-    Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-    SECTION("ERC20 Class Constructor") {
-      Address erc20Address;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20ClassConstructor";
-        std::string tokenName = "TestToken";
-        std::string tokenSymbol = "TST";
-        uint8_t tokenDecimals = 18;
-        uint256_t tokenSupply = 1000000000000000000;
-        initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals, tokenSupply);
-
-        erc20Address = contractManager->getContracts()[0].second;
-
-        Bytes nameEncoder = Bytes(32, 0);
-        Bytes symbolEncoder = Bytes(32, 0);
-        Bytes decimalsEncoder = Bytes(32, 0);
-        Bytes totalSupplyEncoder = Bytes(32, 0);
-
-        Functor nameFunctor = ABI::FunctorEncoder::encode<void>("name");
-        Functor symbolFunctor = ABI::FunctorEncoder::encode<void>("symbol");
-        Functor decimalsFunctor = ABI::FunctorEncoder::encode<void>("decimals");
-        Functor totalSupplyFunctor = ABI::FunctorEncoder::encode<void>("totalSupply");
-
-        Bytes nameData = contractManager->callContract(buildCallInfo(erc20Address, nameFunctor, nameEncoder));
-
-        auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-        REQUIRE(std::get<0>(nameDecoder) == tokenName);
-
-        Bytes symbolData = contractManager->callContract(buildCallInfo(erc20Address, symbolFunctor, symbolEncoder));
-
-        auto symbolDecoderResult = ABI::Decoder::decodeData<std::string>(symbolData);
-        REQUIRE(std::get<0>(symbolDecoderResult) == tokenSymbol);
-
-        Bytes decimalsData = contractManager->callContract(buildCallInfo(erc20Address, decimalsFunctor, decimalsEncoder));
-
-        auto decimalsDecoder = ABI::Decoder::decodeData<uint256_t>(decimalsData);
-        REQUIRE(std::get<0>(decimalsDecoder) == 18);
-
-        Bytes totalSupplyData = contractManager->callContract(buildCallInfo(erc20Address, totalSupplyFunctor, totalSupplyEncoder));
-
-        auto totalSupplyDecoder = ABI::Decoder::decodeData<uint256_t>(totalSupplyData);
-        REQUIRE(std::get<0>(totalSupplyDecoder) == tokenSupply);
-
-        Bytes balanceOfData = contractManager->callContract(buildCallInfo(erc20Address, totalSupplyFunctor, totalSupplyEncoder));
-
-        auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-        REQUIRE(std::get<0>(balanceOfDecoder) == tokenSupply);
-      }
-
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20ClassConstructor";
-      std::string tokenName = "TestToken";
-      std::string tokenSymbol = "TST";
-      uint8_t tokenDecimals = 18;
-      uint256_t tokenSupply = 1000000000000000000;
-      initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals, tokenSupply, false);
-
-      REQUIRE(erc20Address == contractManager->getContracts()[0].second);
-    
-      Bytes nameEncoder = Bytes(32, 0);
-      Bytes symbolEncoder = Bytes(32, 0);
-      Bytes decimalsEncoder = Bytes(32, 0);
-      Bytes totalSupplyEncoder = Bytes(32, 0);
-
-      Functor nameFunctor = ABI::FunctorEncoder::encode<void>("name");
-      Functor symbolFunctor = ABI::FunctorEncoder::encode<void>("symbol");
-      Functor decimalsFunctor = ABI::FunctorEncoder::encode<void>("decimals");
-      Functor totalSupplyFunctor = ABI::FunctorEncoder::encode<void>("totalSupply");
-
-      Bytes nameData = contractManager->callContract(buildCallInfo(erc20Address, nameFunctor, nameEncoder));
-
-      auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-      REQUIRE(std::get<0>(nameDecoder) == tokenName);
-
-      Bytes symbolData = contractManager->callContract(buildCallInfo(erc20Address, symbolFunctor, symbolEncoder));
-
-      auto symbolDecoder = ABI::Decoder::decodeData<std::string>(symbolData);
-      REQUIRE(std::get<0>(symbolDecoder) == tokenSymbol);
-
-      Bytes decimalsData = contractManager->callContract(buildCallInfo(erc20Address, decimalsFunctor, decimalsEncoder));
-
-      auto decimalsDecoder = ABI::Decoder::decodeData<uint256_t>(decimalsData);
-      REQUIRE(std::get<0>(decimalsDecoder) == 18);
-
-      Bytes totalSupplyData = contractManager->callContract(buildCallInfo(erc20Address, totalSupplyFunctor, totalSupplyEncoder));
-
-      auto totalSupplyDecoder = ABI::Decoder::decodeData<uint256_t>(totalSupplyData);
-      REQUIRE(std::get<0>(totalSupplyDecoder) == tokenSupply);
-
-      Bytes balanceOfData = contractManager->callContract(buildCallInfo(erc20Address, totalSupplyFunctor, totalSupplyEncoder));
-
-      auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-      REQUIRE(std::get<0>(balanceOfDecoder) == tokenSupply);
+    SECTION("ERC20 creation") {
+      SDKTestSuite sdk("testERC20Creation");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::name) == "TestToken");
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::symbol) == "TST");
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::decimals) == 18);
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::totalSupply) == uint256_t("1000000000000000000"));
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::balanceOf, owner) == uint256_t("1000000000000000000"));
     }
 
     SECTION("ERC20 transfer()") {
-      Address erc20Address;
-      Address destinationOfTransactions(Utils::randBytes(20));
+      SDKTestSuite sdk("testERC20Transfer");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
+      Address to(Utils::randBytes(20));
 
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20ClassTransfer";
-        std::string tokenName = "TestToken";
-        std::string tokenSymbol = "TST";
-        uint8_t tokenDecimals = 18;
-        uint256_t tokenSupply = 1000000000000000000;
-        initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                   tokenSupply);
+      uint256_t balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      uint256_t balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("1000000000000000000")); // 1 TST
+      REQUIRE(balanceTo == 0);
 
-        erc20Address = contractManager->getContracts()[0].second;
+      Hash transferTx = sdk.callFunction(erc20, &ERC20::transfer, to, uint256_t("500000000000000000")); // 0.5 TST
+      balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("500000000000000000"));
+      REQUIRE(balanceTo == uint256_t("500000000000000000"));
 
-        Bytes getBalanceMeEncoder = ABI::Encoder::encodeData(owner);
-        Functor getBalanceMeFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfTransactions);
-        Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes transferData = Hex::toBytes("0xa9059cbb");
-
-        Bytes transferEncoder = ABI::Encoder::encodeData(destinationOfTransactions, static_cast<uint256_t>(500000000000000000));
-        Utils::appendBytes(transferData, transferEncoder);
-        TxBlock transferTx(
-          erc20Address,
-          owner,
-          transferData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        auto randomPrivKey = PrivKey(Utils::randBytes(32));
-        TxBlock transferTxThrows = TxBlock(
-          erc20Address,
-          Secp256k1::toAddress(Secp256k1::toUPub(randomPrivKey)),
-          transferData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          randomPrivKey
-        );
-
-        REQUIRE_THROWS(contractManager->validateCallContractWithTx(transferTxThrows.txToCallInfo()));
-        contractManager->validateCallContractWithTx(transferTx.txToCallInfo());
-
-        Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceMeFunctor, getBalanceMeEncoder));
-
-        auto getBalanceMeDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-        REQUIRE(std::get<0>(getBalanceMeDecoder) == 1000000000000000000);
-
-        Bytes getBalanceDestinationResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceDestinationFunctor, getBalanceDestinationEncoder));
-
-        auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-        REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 0);
-
-        REQUIRE_THROWS(contractManager->callContract(transferTxThrows));
-        contractManager->callContract(transferTx);
-
-        getBalanceMeResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceMeFunctor, getBalanceMeEncoder));
-
-        auto getBalanceMeDecoder2 = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-        REQUIRE(std::get<0>(getBalanceMeDecoder2) == 500000000000000000);
-
-        getBalanceDestinationResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceDestinationFunctor, getBalanceDestinationEncoder));
-
-        auto getBalanceDestinationDecoder2 = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-        REQUIRE(std::get<0>(getBalanceDestinationDecoder2) == 500000000000000000);
-
-      }
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20ClassTransfer";
-      std::string tokenName = "TestToken";
-      std::string tokenSymbol = "TST";
-      uint8_t tokenDecimals = 18;
-      uint256_t tokenSupply = 1000000000000000000;
-      initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                   tokenSupply, false);
-
-      REQUIRE(erc20Address == contractManager->getContracts()[0].second);
-
-      Bytes getBalanceMeEncoder = ABI::Encoder::encodeData(owner);
-      Functor getBalanceMeFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfTransactions);
-      Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceMeFunctor, getBalanceMeEncoder));
-
-      auto getBalanceMeDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-      REQUIRE(std::get<0>(getBalanceMeDecoder) == 500000000000000000);
-
-      Bytes getBalanceDestinationResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceDestinationFunctor, getBalanceDestinationEncoder));
-
-      auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-      REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 500000000000000000);
+      // "owner" doesn't have enough balance, this should throw and balances should stay intact
+      Hash transferFailTx = sdk.callFunction(erc20, &ERC20::transfer, to, uint256_t("1000000000000000000"));
+      balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("500000000000000000"));
+      REQUIRE(balanceTo == uint256_t("500000000000000000"));
     }
 
-    SECTION("ERC20 Approve") {
-      Address erc20Address;
-      Address destinationOfApproval(Utils::randBytes(20));
+    SECTION("ERC20 approve()") {
+      SDKTestSuite sdk("testERC20Approve");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
+      Address to(Utils::randBytes(20));
 
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20ClassApprove";
-        std::string tokenName = "TestToken";
-        std::string tokenSymbol = "TST";
-        uint8_t tokenDecimals = 18;
-        uint256_t tokenSupply = 1000000000000000000;
-        initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                   tokenSupply);
-
-        erc20Address = contractManager->getContracts()[0].second;
-
-        Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, destinationOfApproval);
-        Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
-
-        Bytes approveEncoder = ABI::Encoder::encodeData(destinationOfApproval, static_cast<uint256_t>(500000000000000000));
-        Bytes approveData = Hex::toBytes("0x095ea7b3");
-        Utils::appendBytes(approveData, approveEncoder);
-        TxBlock approveTx(
-          erc20Address,
-          owner,
-          approveData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->validateCallContractWithTx(approveTx.txToCallInfo());
-
-        Bytes getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-        REQUIRE(std::get<0>(getAllowanceDecoder) == 0);
-
-        contractManager->callContract(approveTx);
-
-        getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-        REQUIRE(std::get<0>(getAllowanceDecoder) == 500000000000000000);
-
-      }
-
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20ClassApprove";
-      std::string tokenName = "TestToken";
-      std::string tokenSymbol = "TST";
-      uint8_t tokenDecimals = 18;
-      uint256_t tokenSupply = 1000000000000000000;
-      initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                 tokenSupply, false);
-
-      REQUIRE(erc20Address == contractManager->getContracts()[0].second);
-
-      Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, destinationOfApproval);
-      Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
-
-      Bytes getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-      auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-      REQUIRE(std::get<0>(getAllowanceDecoder) == 500000000000000000);
+      uint256_t allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, to);
+      REQUIRE(allowance == 0); // "to" is not allowed (yet) to spend anything on behalf of "erc20"
+      Hash approveTx = sdk.callFunction(erc20, &ERC20::approve, to, uint256_t("500000000000000000"));
+      allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, to);
+      REQUIRE(allowance == uint256_t("500000000000000000")); // "to" can now spend 0.5 TST
     }
 
-    SECTION("ERC20 transferFrom") {
-      PrivKey destinationOfApprovalPrivKey(Utils::randBytes(32));
-      Address destinationOfApproval(Secp256k1::toAddress(Secp256k1::toUPub(destinationOfApprovalPrivKey)));
-      Address erc20Address;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20ClassTransferFrom";
-        std::string tokenName = "TestToken";
-        std::string tokenSymbol = "TST";
-        uint8_t tokenDecimals = 18;
-        uint256_t tokenSupply = 1000000000000000000;
-        initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                   tokenSupply);
+    SECTION("ERC20 transferFrom()") {
+      SDKTestSuite sdk("testERC20TransferFrom");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
+      Address to(Utils::randBytes(20));
 
-        erc20Address = contractManager->getContracts()[0].second;
+      // Check "owner" has 1 TST and "to" has 0 TST
+      uint256_t balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      uint256_t balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("1000000000000000000")); // 1 TST
+      REQUIRE(balanceTo == 0);
 
-        Bytes approveEncoder = ABI::Encoder::encodeData(destinationOfApproval, static_cast<uint256_t>(500000000000000000));
-        Bytes approveData = Hex::toBytes("0x095ea7b3");
-        Utils::appendBytes(approveData, approveEncoder);
-        TxBlock approveTx(
-          erc20Address,
-          owner,
-          approveData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
+      // Approve "owner" first so it can spend up to 3 TST
+      // (it doesn't have that much, but it's on purpose so we can test invalid balances)
+      Hash approveTx = sdk.callFunction(erc20, &ERC20::approve, owner, uint256_t("3000000000000000000"));
+      REQUIRE(sdk.callViewFunction(erc20, &ERC20::allowance, owner, owner) == uint256_t("3000000000000000000"));
 
-        contractManager->callContract(approveTx);
+      // Transfer 0.5 TST specifically from "owner" to "to"
+      Hash transferTx = sdk.callFunction(erc20, &ERC20::transferFrom, owner, to, uint256_t("500000000000000000"));
+      balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("500000000000000000"));
+      REQUIRE(balanceTo == uint256_t("500000000000000000"));
 
-        Bytes transferFromEncoder = ABI::Encoder::encodeData(owner, destinationOfApproval, static_cast<uint256_t>(500000000000000000));
-        Bytes transferFromBytes = Hex::toBytes("0x23b872dd");
-        Utils::appendBytes(transferFromBytes, transferFromEncoder);
-        TxBlock transferFromTx(
-          erc20Address,
-          destinationOfApproval,
-          transferFromBytes,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          destinationOfApprovalPrivKey
-        );
-
-        auto randomPrivKey = PrivKey(Utils::randBytes(32));
-        TxBlock transferFromTxThrows = TxBlock(
-          erc20Address,
-          Secp256k1::toAddress(Secp256k1::toUPub(randomPrivKey)),
-          transferFromBytes,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          randomPrivKey
-        );
-
-        REQUIRE_THROWS(contractManager->validateCallContractWithTx(transferFromTxThrows.txToCallInfo()));
-        contractManager->validateCallContractWithTx(transferFromTx.txToCallInfo());
-
-        Bytes getBalanceMeEncoder = ABI::Encoder::encodeData(owner);
-        Functor getBalanceMeFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(
-          erc20Address, getBalanceMeFunctor, getBalanceMeEncoder
-        ));
-
-        auto getBalanceMeDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-        REQUIRE(std::get<0>(getBalanceMeDecoder) == 1000000000000000000);
-
-        Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfApproval);
-        Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceDestinationResult = contractManager->callContract(buildCallInfo(
-          erc20Address,
-          getBalanceDestinationFunctor,
-          getBalanceDestinationEncoder
-        ));
-
-        auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-        REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 0);
-
-        REQUIRE_THROWS(contractManager->callContract(transferFromTxThrows));
-        contractManager->callContract(transferFromTx);
-
-        getBalanceMeResult = contractManager->callContract(buildCallInfo(
-          erc20Address, getBalanceMeFunctor, getBalanceMeEncoder
-        ));
-
-        getBalanceMeDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-        REQUIRE(std::get<0>(getBalanceMeDecoder) == 500000000000000000);
-
-        getBalanceDestinationResult = contractManager->callContract(buildCallInfo(
-          erc20Address,
-          getBalanceDestinationFunctor,
-          getBalanceDestinationEncoder
-        ));
-        getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-        REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 500000000000000000);
-      }
-
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20ClassTransferFrom";
-      std::string tokenName = "TestToken";
-      std::string tokenSymbol = "TST";
-      uint8_t tokenDecimals = 18;
-      uint256_t tokenSupply = 1000000000000000000;
-      initialize(options, db, contractManager, dbName, ownerPrivKey, tokenName, tokenSymbol, tokenDecimals,
-                 tokenSupply, false);
-
-      Bytes getBalanceMeEncoder = ABI::Encoder::encodeData(owner);
-      Functor getBalanceMeFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceMeResult = contractManager->callContract(buildCallInfo(
-        erc20Address, getBalanceMeFunctor, getBalanceMeEncoder
-      ));
-
-      auto getBalanceMeDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceMeResult);
-      REQUIRE(std::get<0>(getBalanceMeDecoder) == 500000000000000000);
-
-      Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfApproval);
-      Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceDestinationResult = contractManager->callContract(buildCallInfo(
-        erc20Address,
-        getBalanceDestinationFunctor,
-        getBalanceDestinationEncoder
-      ));
-
-      auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-      REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 500000000000000000);
+      // "owner" doesn't have enough balance, this should throw and balances should stay intact
+      Hash transferFailTx = sdk.callFunction(erc20, &ERC20::transferFrom, owner, to, uint256_t("1000000000000000000"));
+      balanceMe = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      balanceTo = sdk.callViewFunction(erc20, &ERC20::balanceOf, to);
+      REQUIRE(balanceMe == uint256_t("500000000000000000"));
+      REQUIRE(balanceTo == uint256_t("500000000000000000"));
     }
   }
 }
+

--- a/tests/contract/erc20wrapper.cpp
+++ b/tests/contract/erc20wrapper.cpp
@@ -7,656 +7,127 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "../../src/libs/catch2/catch_amalgamated.hpp"
 #include "../../src/contract/templates/erc20.h"
+#include "../../src/contract/templates/erc20wrapper.h"
 #include "../../src/contract/abi.h"
 #include "../../src/utils/db.h"
 #include "../../src/utils/options.h"
 #include "../../src/contract/contractmanager.h"
 #include "../../src/core/rdpos.h"
 
+#include "../sdktestsuite.hpp"
+
 #include <filesystem>
 #include <string>
 
-// Forward declaration.
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
-
-void initialize(std::unique_ptr<Options>& options,
-                std::unique_ptr<DB>& db,
-                std::unique_ptr<ContractManager> &contractManager,
-                const std::string& dbName,
-                const PrivKey& ownerPrivKey,
-                bool deleteDB = true) {
-  if (deleteDB) {
-    if (std::filesystem::exists(dbName)) {
-      std::filesystem::remove_all(dbName);
-    }
-  }
-
-  options = std::make_unique<Options>(Options::fromFile(dbName));
-  db = std::make_unique<DB>(dbName);
-  std::unique_ptr<rdPoS> rdpos;
-  contractManager = std::make_unique<ContractManager>(nullptr, db, rdpos, options);
-
-  if (deleteDB) {
-    /// Create the contract.
-
-    Bytes createNewERC20ContractEncoder = ABI::Encoder::encodeData(std::string("TestToken"), std::string("TST"), 18, 1000000000000000000);
-    Bytes createNewERC20ContractData = Hex::toBytes("0xb74e5ed5");
-    Utils::appendBytes(createNewERC20ContractData, createNewERC20ContractEncoder);
-
-    TxBlock createNewERC2OTx = TxBlock(
-      ProtocolContractAddresses.at("ContractManager"),
-      Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-      createNewERC20ContractData,
-      8080,
-      0,
-      0,
-      0,
-      0,
-      0,
-      ownerPrivKey
-    );
-
-    contractManager->callContract(createNewERC2OTx);
-
-    TxBlock createNewERC20Wrapper = TxBlock(
-      ProtocolContractAddresses.at("ContractManager"),
-      Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-      Hex::toBytes("0x97aa51a3"),
-      8080,
-      0,
-      0,
-      0,
-      0,
-      0,
-      ownerPrivKey
-    );
-
-    contractManager->callContract(createNewERC20Wrapper);
-  }
-}
+// TODO: test events if/when implemented
 
 namespace TERC20Wrapper {
-  std::string testDumpPath = Utils::getTestDumpPath();
   TEST_CASE("ERC20Wrapper Class", "[contract][erc20wrapper]") {
-    PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-    Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-    SECTION("ERC20Wrapper Constructor Test") {
-      Address erc20Address;
-      Address wrapperAddress;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20wrapperDb";
-        initialize(options, db, contractManager, dbName, ownerPrivKey);
-        for (const auto& [name, address] : contractManager->getContracts()) {
-          if (name == "ERC20") {
-            erc20Address = address;
-          }
-          if (name == "ERC20Wrapper") {
-            wrapperAddress = address;
-          }
-        }
-      }
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20wrapperDb";
-      initialize(options, db, contractManager, dbName, ownerPrivKey, false);
-
-      for (const auto& [name, address] : contractManager->getContracts()) {
-        if (name == "ERC20") {
-          REQUIRE(erc20Address == address);
-        }
-        if (name == "ERC20Wrapper") {
-          REQUIRE(wrapperAddress == address);
-        }
+    SECTION("ERC20Wrapper creation") {
+      SDKTestSuite sdk("testERC20Creation");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address erc20Wrapper = sdk.deployContract<ERC20Wrapper>();
+      Address owner = sdk.getChainOwnerAccount().address;
+      for (const auto& [name, address] : sdk.getState()->getContracts()) {
+        if (name == "ERC20") REQUIRE(address == erc20);
+        if (name == "ERC20Wrapper") REQUIRE(address == erc20Wrapper);
       }
     }
 
-    SECTION("ERC20Wrapper Deposit") {
-      Address erc20Address;
-      Address wrapperAddress;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20wrapperDb";
-        initialize(options, db, contractManager, dbName, ownerPrivKey);
-        for (const auto &[name, address]: contractManager->getContracts()) {
-          if (name == "ERC20") {
-            erc20Address = address;
-          }
-          if (name == "ERC20Wrapper") {
-            wrapperAddress = address;
-          }
-        }
-
-        Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-        Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address, Address>("allowance");
-
-        Bytes depositEncoder = ABI::Encoder::encodeData(erc20Address, static_cast<uint256_t>(500000000000000000));
-        Bytes depositData = Hex::toBytes("0x47e7ef24");
-        Utils::appendBytes(depositData, depositEncoder);
-        TxBlock depositTx(
-          wrapperAddress,
-          owner,
-          depositData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        // Try to deposit without approving first.
-        REQUIRE_THROWS(contractManager->callContract(depositTx));
-
-        Bytes approveEncoder = ABI::Encoder::encodeData(wrapperAddress, static_cast<uint256_t>(500000000000000000));
-        Bytes approveData = Hex::toBytes("0x095ea7b3");
-        Utils::appendBytes(approveData, approveEncoder);
-        TxBlock approveTx(
-          erc20Address,
-          owner,
-          approveData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->callContract(approveTx);
-
-        Bytes getAllowanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-        REQUIRE(std::get<0>(getAllowanceDecoder) == 500000000000000000);
-
-        contractManager->callContract(depositTx);
-        Bytes getAllowanceResult2 = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder2 = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult2);
-        REQUIRE(std::get<0>(getAllowanceDecoder2) == 0);
-
-        Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-        Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-
-        Bytes getContractBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-        auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-        REQUIRE(std::get<0>(getContractBalanceDecoder) == 500000000000000000);
-
-        Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-        Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-
-        Bytes getUserBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-        auto getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-        REQUIRE(std::get<0>(getUserBalanceDecoder) == 500000000000000000);
-
-        Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-        Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-        auto getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-        REQUIRE(std::get<0>(getBalanceDecoder) == 500000000000000000);
-
-        Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-        Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceWrapperResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-        auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 500000000000000000);
-
+    SECTION("ERC20Wrapper deposit() and withdraw()") {
+      SDKTestSuite sdk("testERC20DepositAndWithdraw");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address erc20Wrapper = sdk.deployContract<ERC20Wrapper>();
+      Address owner = sdk.getChainOwnerAccount().address;
+      for (const auto& [name, address] : sdk.getState()->getContracts()) {
+        if (name == "ERC20") REQUIRE(address == erc20);
+        if (name == "ERC20Wrapper") REQUIRE(address == erc20Wrapper);
       }
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20wrapperDb";
-      initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
-      Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-      Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
+      // Try depositing without allowance first
+      uint256_t allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, erc20Wrapper);
+      REQUIRE(allowance == 0);  // "erc20Wrapper" is not allowed (yet) to spend anything on behalf of "owner"
+      Hash depositFailTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::deposit, erc20, uint256_t("500000000000000000"));
+      REQUIRE(sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner) == 0);
 
-      Bytes getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
+      // Allow "erc20Wrapper" and make a deposit of 0.5 TST
+      Hash approveTx = sdk.callFunction(erc20, &ERC20::approve, erc20Wrapper, uint256_t("500000000000000000"));
+      allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, erc20Wrapper);
+      REQUIRE(allowance == uint256_t("500000000000000000"));  // "erc20Wrapper" is allowed to spend 0.5 TST on behalf of "owner"
+      Hash depositTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::deposit, erc20, uint256_t("500000000000000000"));
+      uint256_t userBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner);
+      uint256_t contractBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getContractBalance, erc20);
+      uint256_t erc20Bal = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      uint256_t wrapperBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, erc20Wrapper);
+      REQUIRE(userBal == uint256_t("500000000000000000"));
+      REQUIRE(contractBal == uint256_t("500000000000000000"));
+      REQUIRE(erc20Bal == uint256_t("500000000000000000"));
+      REQUIRE(wrapperBal == uint256_t("500000000000000000"));
 
-      auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-      REQUIRE(std::get<0>(getAllowanceDecoder) == 0);
-
-      Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-      Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-
-      Bytes getContractBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-      auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-      REQUIRE(std::get<0>(getContractBalanceDecoder) == 500000000000000000);
-
-      Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-      Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-
-      Bytes getUserBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-      auto getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-      REQUIRE(std::get<0>(getUserBalanceDecoder) == 500000000000000000);
-
-      Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-      Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-      auto getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-      REQUIRE(std::get<0>(getBalanceDecoder) == 500000000000000000);
-
-      Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-      Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceWrapperResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-      auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-      REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 500000000000000000);
+      // Withdraw 0.25 TST
+      Hash withdrawTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::withdraw, erc20, uint256_t("250000000000000000"));
+      userBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner);
+      contractBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getContractBalance, erc20);
+      erc20Bal = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      wrapperBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, erc20Wrapper);
+      REQUIRE(userBal == uint256_t("250000000000000000"));
+      REQUIRE(contractBal == uint256_t("250000000000000000"));
+      REQUIRE(erc20Bal == uint256_t("750000000000000000"));
+      REQUIRE(wrapperBal == uint256_t("250000000000000000"));
     }
 
-    SECTION("ERC20Wrapper Withdraw") {
-      Address erc20Address;
-      Address wrapperAddress;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20wrapperDb";
-        initialize(options, db, contractManager, dbName, ownerPrivKey);
-        for (const auto &[name, address]: contractManager->getContracts()) {
-          if (name == "ERC20") {
-            erc20Address = address;
-          }
-          if (name == "ERC20Wrapper") {
-            wrapperAddress = address;
-          }
-        }
-
-        Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-        Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
-
-        Bytes depositData = Hex::toBytes("0x47e7ef24");
-        Bytes depositEncoder = ABI::Encoder::encodeData(erc20Address, static_cast<uint256_t>(500000000000000000));
-        Utils::appendBytes(depositData, depositEncoder);
-        TxBlock depositTx(
-          wrapperAddress,
-          owner,
-          depositData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        REQUIRE_THROWS(contractManager->callContract(depositTx));
-
-        Bytes approveEncoder = ABI::Encoder::encodeData(wrapperAddress, static_cast<uint256_t>(500000000000000000));
-        Bytes approveData = Hex::toBytes("0x095ea7b3");
-        Utils::appendBytes(approveData, approveEncoder);
-        TxBlock approveTx(
-          erc20Address,
-          owner,
-          approveData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->callContract(approveTx);
-
-        Bytes getAllowanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-        REQUIRE(std::get<0>(getAllowanceDecoder) == 500000000000000000);
-
-        contractManager->callContract(depositTx);
-        Bytes getAllowanceResult2 = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder2 = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult2);
-        REQUIRE(std::get<0>(getAllowanceDecoder2) == 0);
-
-        Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-        Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-
-        Bytes getContractBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-        auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-        REQUIRE(std::get<0>(getContractBalanceDecoder) == 500000000000000000);
-
-        Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-        Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-
-        Bytes getUserBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-        auto getUserBalanceDecoder= ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-        REQUIRE(std::get<0>(getUserBalanceDecoder) == 500000000000000000);
-
-        Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-        Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes getBalanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-        auto getBalanceDecoder  = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-        REQUIRE(std::get<0>(getBalanceDecoder) == 500000000000000000);
-
-        Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-        Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes getBalanceWrapperResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-        auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 500000000000000000);
-
-        Bytes withdrawEncoder = ABI::Encoder::encodeData(erc20Address, static_cast<uint256_t>(250000000000000000));
-        Bytes withdrawData = Hex::toBytes("0xf3fef3a3");
-        Utils::appendBytes(withdrawData, withdrawEncoder);
-        TxBlock withdrawTx(
-          wrapperAddress,
-          owner,
-          withdrawData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->callContract(withdrawTx);
-
-        getContractBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-        getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-        REQUIRE(std::get<0>(getContractBalanceDecoder) == 250000000000000000);
-
-        getUserBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-        getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-        REQUIRE(std::get<0>(getUserBalanceDecoder) == 250000000000000000);
-
-        getBalanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-        getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-        REQUIRE(std::get<0>(getBalanceDecoder) == 750000000000000000);
-
-        getBalanceWrapperResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-        getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 250000000000000000);
+    SECTION("ERC20Wrapper transferTo()") {
+      SDKTestSuite sdk("testERC20TransferTo");
+      Address erc20 = sdk.deployContract<ERC20>(
+        std::string("TestToken"), std::string("TST"), uint8_t(18), uint256_t("1000000000000000000")
+      );
+      Address erc20Wrapper = sdk.deployContract<ERC20Wrapper>();
+      Address owner = sdk.getChainOwnerAccount().address;
+      Address dest(Utils::randBytes(20));
+      for (const auto& [name, address] : sdk.getState()->getContracts()) {
+        if (name == "ERC20") REQUIRE(address == erc20);
+        if (name == "ERC20Wrapper") REQUIRE(address == erc20Wrapper);
       }
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20wrapperDb";
-      initialize(options, db, contractManager, dbName, ownerPrivKey, false);
 
-      Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-      Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
+      // Try depositing without allowance first
+      uint256_t allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, erc20Wrapper);
+      REQUIRE(allowance == 0);  // "erc20Wrapper" is not allowed (yet) to spend anything on behalf of "owner"
+      Hash depositFailTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::deposit, erc20, uint256_t("500000000000000000"));
+      REQUIRE(sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner) == 0);
 
-      Bytes getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
+      // Allow "erc20Wrapper" and make a deposit of 0.5 TST
+      Hash approveTx = sdk.callFunction(erc20, &ERC20::approve, erc20Wrapper, uint256_t("500000000000000000"));
+      allowance = sdk.callViewFunction(erc20, &ERC20::allowance, owner, erc20Wrapper);
+      REQUIRE(allowance == uint256_t("500000000000000000"));  // "erc20Wrapper" is allowed to spend 0.5 TST on behalf of "owner"
+      Hash depositTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::deposit, erc20, uint256_t("500000000000000000"));
+      uint256_t userBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner);
+      uint256_t contractBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getContractBalance, erc20);
+      uint256_t erc20Bal = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      uint256_t wrapperBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, erc20Wrapper);
+      uint256_t destBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, dest);
+      REQUIRE(userBal == uint256_t("500000000000000000"));
+      REQUIRE(contractBal == uint256_t("500000000000000000"));
+      REQUIRE(erc20Bal == uint256_t("500000000000000000"));
+      REQUIRE(wrapperBal == uint256_t("500000000000000000"));
+      REQUIRE(destBal == 0);
 
-      auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-      REQUIRE(std::get<0>(getAllowanceDecoder) == 0);
-
-      Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-      Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-      Bytes getContractBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-      auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-      REQUIRE(std::get<0>(getContractBalanceDecoder) == 250000000000000000);
-
-      Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-      Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-      Bytes getUserBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-      auto getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-      REQUIRE(std::get<0>(getUserBalanceDecoder) == 250000000000000000);
-
-      Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-      Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-      Bytes getBalanceResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-      auto getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-      REQUIRE(std::get<0>(getBalanceDecoder) == 750000000000000000);
-
-      Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-      Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-      Bytes getBalanceWrapperResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-      auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-      REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 250000000000000000);
-    }
-
-    SECTION("ERC20Wrapper transferTo") {
-      Address erc20Address;
-      Address wrapperAddress;
-      Address destinationOfTransfers(Utils::randBytes(20));
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        std::string dbName = testDumpPath + "/erc20wrapperDb";
-        initialize(options, db, contractManager, dbName, ownerPrivKey);
-        for (const auto &[name, address]: contractManager->getContracts()) {
-          if (name == "ERC20") {
-            erc20Address = address;
-          }
-          if (name == "ERC20Wrapper") {
-            wrapperAddress = address;
-          }
-        }
-
-        Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-        Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
-
-        Bytes depositEncoder = ABI::Encoder::encodeData(erc20Address, static_cast<uint256_t>(500000000000000000));
-        Bytes depositData = Hex::toBytes("0x47e7ef24");
-        Utils::appendBytes(depositData, depositEncoder);
-        TxBlock depositTx(
-          wrapperAddress,
-          owner,
-          depositData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        REQUIRE_THROWS(contractManager->callContract(depositTx));
-
-        Bytes approveEncoder = ABI::Encoder::encodeData(wrapperAddress, static_cast<uint256_t>(500000000000000000));
-        Bytes approveData = Hex::toBytes("0x095ea7b3");
-        Utils::appendBytes(approveData, approveEncoder);
-        TxBlock approveTx(
-          erc20Address,
-          owner,
-          approveData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->callContract(approveTx);
-
-        Bytes getAllowanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-        REQUIRE(std::get<0>(getAllowanceDecoder) == 500000000000000000);
-
-        contractManager->callContract(depositTx);
-        Bytes getAllowanceResult2 = contractManager->callContract(
-          buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-        auto getAllowanceDecoder2 = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult2);
-        REQUIRE(std::get<0>(getAllowanceDecoder2) == 0);
-
-        Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-        Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-
-        Bytes getContractBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-        auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-        REQUIRE(std::get<0>(getContractBalanceDecoder) == 500000000000000000);
-
-        Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-        Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-
-        Bytes getUserBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-        auto getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-        REQUIRE(std::get<0>(getUserBalanceDecoder) == 500000000000000000);
-
-        Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-        Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes getBalanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-        auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 500000000000000000);
-
-        Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-        Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes getBalanceWrapperResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-        getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 500000000000000000);
-
-        Bytes transferToEncoder = ABI::Encoder::encodeData(erc20Address, destinationOfTransfers, static_cast<uint256_t>(250000000000000000));
-        Bytes transferToData = Hex::toBytes("0xa5f2a152");
-        Utils::appendBytes(transferToData, transferToEncoder);
-        TxBlock transferTx(
-          wrapperAddress,
-          owner,
-          transferToData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        contractManager->callContract(transferTx);
-
-        getContractBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-        getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-        REQUIRE(std::get<0>(getContractBalanceDecoder) == 250000000000000000);
-
-        getUserBalanceResult = contractManager->callContract(
-          buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-        getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-        REQUIRE(std::get<0>(getUserBalanceDecoder) == 250000000000000000);
-
-        getBalanceResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-        auto getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-        REQUIRE(std::get<0>(getBalanceDecoder) == 500000000000000000);
-
-        getBalanceWrapperResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-        getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-        REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 250000000000000000);
-
-        Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfTransfers);
-        Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes getBalanceDestinationResult = contractManager->callContract(
-          buildCallInfo(erc20Address, getBalanceDestinationFunctor, getBalanceDestinationEncoder));
-
-        auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-        REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 250000000000000000);
-      }
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      std::string dbName = testDumpPath + "/erc20wrapperDb";
-      initialize(options, db, contractManager, dbName, ownerPrivKey, false);
-
-      Bytes getAllowanceEncoder = ABI::Encoder::encodeData(owner, wrapperAddress);
-      Functor getAllowanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("allowance");
-
-      Bytes getAllowanceResult = contractManager->callContract(buildCallInfo(erc20Address, getAllowanceFunctor, getAllowanceEncoder));
-
-      auto getAllowanceDecoder = ABI::Decoder::decodeData<uint256_t>(getAllowanceResult);
-      REQUIRE(std::get<0>(getAllowanceDecoder) == 0);
-
-      Bytes getContractBalanceEncoder = ABI::Encoder::encodeData(erc20Address);
-      Functor getContractBalanceFunctor = ABI::FunctorEncoder::encode<Address>("getContractBalance");
-      Bytes getContractBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getContractBalanceFunctor, getContractBalanceEncoder));
-
-      auto getContractBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getContractBalanceResult);
-      REQUIRE(std::get<0>(getContractBalanceDecoder) == 250000000000000000);
-
-      Bytes getUserBalanceEncoder = ABI::Encoder::encodeData(erc20Address, owner);
-      Functor getUserBalanceFunctor = ABI::FunctorEncoder::encode<Address,Address>("getUserBalance");
-      Bytes getUserBalanceResult = contractManager->callContract(buildCallInfo(wrapperAddress, getUserBalanceFunctor, getUserBalanceEncoder));
-
-      auto getUserBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getUserBalanceResult);
-      REQUIRE(std::get<0>(getUserBalanceDecoder) == 250000000000000000);
-
-      Bytes getBalanceEncoder = ABI::Encoder::encodeData(owner);
-      Functor getBalanceFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-      Bytes getBalanceResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceFunctor, getBalanceEncoder));
-
-      auto getBalanceDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceResult);
-      REQUIRE(std::get<0>(getBalanceDecoder) == 500000000000000000);
-
-      Bytes getBalanceWrapperEncoder = ABI::Encoder::encodeData(wrapperAddress);
-      Functor getBalanceWrapperFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes getBalanceWrapperResult = contractManager->callContract(buildCallInfo(erc20Address, getBalanceWrapperFunctor, getBalanceWrapperEncoder));
-
-      auto getBalanceWrapperDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceWrapperResult);
-      REQUIRE(std::get<0>(getBalanceWrapperDecoder) == 250000000000000000);
-
-      Bytes getBalanceDestinationEncoder = ABI::Encoder::encodeData(destinationOfTransfers);
-      Functor getBalanceDestinationFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-      Bytes getBalanceDestinationResult = contractManager->callContract(
-        buildCallInfo(erc20Address, getBalanceDestinationFunctor, getBalanceDestinationEncoder));
-
-      auto getBalanceDestinationDecoder = ABI::Decoder::decodeData<uint256_t>(getBalanceDestinationResult);
-      REQUIRE(std::get<0>(getBalanceDestinationDecoder) == 250000000000000000);
+      // Transfer 0.25 TST to "dest"
+      Hash transferTx = sdk.callFunction(erc20Wrapper, &ERC20Wrapper::transferTo, erc20, dest, uint256_t("250000000000000000"));
+      userBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getUserBalance, erc20, owner);
+      contractBal = sdk.callViewFunction(erc20Wrapper, &ERC20Wrapper::getContractBalance, erc20);
+      erc20Bal = sdk.callViewFunction(erc20, &ERC20::balanceOf, owner);
+      wrapperBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, erc20Wrapper);
+      destBal = sdk.callViewFunction(erc20, &ERC20::balanceOf, dest);
+      REQUIRE(userBal == uint256_t("250000000000000000"));
+      REQUIRE(contractBal == uint256_t("250000000000000000"));
+      REQUIRE(erc20Bal == uint256_t("500000000000000000"));
+      REQUIRE(wrapperBal == uint256_t("250000000000000000"));
+      REQUIRE(destBal == uint256_t("250000000000000000"));
     }
   }
 }
+

--- a/tests/contract/expectedABI.cpp
+++ b/tests/contract/expectedABI.cpp
@@ -852,7 +852,7 @@ namespace EXPECTED
                                     "    \"anonymous\": false,\n"
                                     "    \"inputs\": [\n"
                                     "      {\n"
-                                    "        \"indexed\": true,\n"
+                                    "        \"indexed\": false,\n"
                                     "        \"internalType\": \"uint256\",\n"
                                     "        \"name\": \"value\",\n"
                                     "        \"type\": \"uint256\"\n"

--- a/tests/contract/nativewrapper.cpp
+++ b/tests/contract/nativewrapper.cpp
@@ -7,6 +7,7 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "../../src/libs/catch2/catch_amalgamated.hpp"
 #include "../../src/contract/templates/erc20.h"
+#include "../../src/contract/templates/nativewrapper.h"
 #include "../../src/contract/abi.h"
 #include "../../src/utils/db.h"
 #include "../../src/utils/options.h"
@@ -15,366 +16,41 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/core/state.h"
 #include "../../src/core/rdpos.h"
 
-// Forward declaration.
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
+#include "../sdktestsuite.hpp"
 
-void initialize(std::unique_ptr<DB>& db,
-                std::unique_ptr<Storage>& storage,
-                std::unique_ptr<P2P::ManagerNormal>& p2p,
-                std::unique_ptr<rdPoS>& rdpos,
-                std::unique_ptr<State>& state,
-                std::unique_ptr<Options>& options,
-                PrivKey validatorKey,
-                uint64_t serverPort,
-                bool clearDb,
-                std::string folderName);
-
-Block createValidBlock(std::unique_ptr<rdPoS>& rdpos, std::unique_ptr<Storage>& storage, const std::vector<TxBlock>& txs = {});
-
-const std::vector<Hash> validatorPrivKeys {
-  Hash(Hex::toBytes("0x0a0415d68a5ec2df57aab65efc2a7231b59b029bae7ff1bd2e40df9af96418c8")),
-  Hash(Hex::toBytes("0xb254f12b4ca3f0120f305cabf1188fe74f0bd38e58c932a3df79c4c55df8fa66")),
-  Hash(Hex::toBytes("0x8a52bb289198f0bcf141688a8a899bf1f04a02b003a8b1aa3672b193ce7930da")),
-  Hash(Hex::toBytes("0x9048f5e80549e244b7899e85a4ef69512d7d68613a3dba828266736a580e7745")),
-  Hash(Hex::toBytes("0x0b6f5ad26f6eb79116da8c98bed5f3ed12c020611777d4de94c3c23b9a03f739")),
-  Hash(Hex::toBytes("0xa69eb3a3a679e7e4f6a49fb183fb2819b7ab62f41c341e2e2cc6288ee22fbdc7")),
-  Hash(Hex::toBytes("0xd9b0613b7e4ccdb0f3a5ab0956edeb210d678db306ab6fae1e2b0c9ebca1c2c5")),
-  Hash(Hex::toBytes("0x426dc06373b694d8804d634a0fd133be18e4e9bcbdde099fce0ccf3cb965492f"))
-};
+// TODO: test events if/when implemented
 
 namespace TNativeWrapper {
   TEST_CASE("NativeWrapper tests", "[contract][nativewrapper]") {
-    std::string testDumpPath = Utils::getTestDumpPath();
-    SECTION("NativeWrapper Constructor") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address contractAddress;
-      std::string tokenName = "WrappedToken";
-      std::string tokenSymbol = "WTKN";
-      uint256_t tokenDecimals = 18;
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                    testDumpPath + "/NativeWrapperNewContractTest");
-
-        // Create a new Contract
-        Bytes createNewNativeWrapperContractEncoder = ABI::Encoder::encodeData(tokenName, tokenSymbol, tokenDecimals);
-        Bytes createNativeWrapperContractData = Hex::toBytes("0xb296fad4");
-        Utils::appendBytes(createNativeWrapperContractData, createNewNativeWrapperContractEncoder);
-
-        TxBlock createNewNativeWrapperTx = TxBlock(
-          ProtocolContractAddresses.at("ContractManager"),
-          owner,
-          createNativeWrapperContractData,
-          8080,
-          0,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        auto newBlock = createValidBlock(rdpos, storage, {createNewNativeWrapperTx});
-        state->processNextBlock(std::move(newBlock));
-
-        // Get the address of the new contract
-        contractAddress = state->getContracts()[0].second;
-        Bytes nameEncoder = Bytes(32, 0);
-        Bytes symbolEncoder = Bytes(32, 0);
-        Bytes decimalsEncoder = Bytes(32, 0);
-        Bytes totalSupplyEncoder = Bytes(32, 0);
-
-        Functor nameFunctor = ABI::FunctorEncoder::encode<void>("name");
-        Functor symbolFunctor = ABI::FunctorEncoder::encode<void>("symbol");
-        Functor decimalsFunctor = ABI::FunctorEncoder::encode<void>("decimals");
-        Functor totalSupplyFunctor = ABI::FunctorEncoder::encode<void>("totalSupply");
-
-        Bytes nameData = state->ethCall(buildCallInfo(contractAddress, nameFunctor, nameEncoder));
-
-        auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-        REQUIRE(std::get<0>(nameDecoder) == tokenName);
-
-        Bytes symbolData = state->ethCall(buildCallInfo(contractAddress, symbolFunctor, symbolEncoder));
-
-        auto symbolDecoder = ABI::Decoder::decodeData<std::string>(symbolData);
-        REQUIRE(std::get<0>(symbolDecoder) == tokenSymbol);
-
-        Bytes decimalsData = state->ethCall(buildCallInfo(contractAddress, decimalsFunctor, decimalsEncoder));
-
-        auto decimalsDecode = ABI::Decoder::decodeData<uint256_t>(decimalsData);
-        REQUIRE(std::get<0>(decimalsDecode) == 18);
-
-        Bytes totalSupplyData = state->ethCall(buildCallInfo(contractAddress, totalSupplyFunctor, totalSupplyEncoder));
-
-        auto totalSupplyDecoder = ABI::Decoder::decodeData<uint256_t>(totalSupplyData);
-        REQUIRE(std::get<0>(totalSupplyDecoder) == 0);
-      }
-      std::unique_ptr<DB> db;
-      std::unique_ptr<Storage> storage;
-      std::unique_ptr<P2P::ManagerNormal> p2p;
-      std::unique_ptr<rdPoS> rdpos;
-      std::unique_ptr<State> state;
-      std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                  testDumpPath + "/NativeWrapperNewContractTest");
-
-      REQUIRE(contractAddress == state->getContracts()[0].second);
-      Bytes nameEncoder = Bytes(32, 0);
-      Bytes symbolEncoder = Bytes(32, 0);
-      Bytes decimalsEncoder = Bytes(32, 0);
-      Bytes totalSupplyEncoder = Bytes(32, 0);
-
-      Functor nameFunctor = ABI::FunctorEncoder::encode<void>("name");
-      Functor symbolFunctor = ABI::FunctorEncoder::encode<void>("symbol");
-      Functor decimalsFunctor = ABI::FunctorEncoder::encode<void>("decimals");
-      Functor totalSupplyFunctor = ABI::FunctorEncoder::encode<void>("totalSupply");
-
-      Bytes nameData = state->ethCall(buildCallInfo(contractAddress, nameFunctor, nameEncoder));
-
-      auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-      REQUIRE(std::get<0>(nameDecoder) == tokenName);
-
-      Bytes symbolData = state->ethCall(buildCallInfo(contractAddress, symbolFunctor, symbolEncoder));
-
-      auto symbolDecoder = ABI::Decoder::decodeData<std::string>(symbolData);
-      REQUIRE(std::get<0>(symbolDecoder) == tokenSymbol);
-
-      Bytes decimalsData = state->ethCall(buildCallInfo(contractAddress, decimalsFunctor, decimalsEncoder));
-
-      auto decimalsDecoder = ABI::Decoder::decodeData<uint256_t>(decimalsData);
-      REQUIRE(std::get<0>(decimalsDecoder) == 18);
-
-      Bytes totalSupplyData = state->ethCall(buildCallInfo(contractAddress, totalSupplyFunctor, totalSupplyEncoder));
-
-      auto totalSupplyDecoder = ABI::Decoder::decodeData<uint256_t>(totalSupplyData);
-      REQUIRE(std::get<0>(totalSupplyDecoder) == 0);
-
+    SECTION("NativeWrapper creation") {
+      SDKTestSuite sdk("testNativeWrapperCreation");
+      Address nativeWrapper = sdk.deployContract<NativeWrapper>(
+        std::string("WrappedToken"), std::string("WTKN"), uint8_t(18)
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::name) == "WrappedToken");
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::symbol) == "WTKN");
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::decimals) == 18);
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::totalSupply) == 0);
     }
 
-    SECTION("NativeWrapper Deposit and Transfer") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address contractAddress;
-      std::string tokenName = "WrappedToken";
-      std::string tokenSymbol = "WTKN";
-      uint256_t tokenDecimals = 18;
-      uint64_t currentNonce = 0;
-      uint256_t amountToTransfer = uint256_t("192838158112259");
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                   testDumpPath + "/NativeWrapperDepositTest");
-
-        // Create a new Contract
-        Bytes createNewNativeWrapperContractEncoder = ABI::Encoder::encodeData(tokenName, tokenSymbol, tokenDecimals);
-        Bytes createNativeWrapperContractData = Hex::toBytes("0xb296fad4");
-        Utils::appendBytes(createNativeWrapperContractData, createNewNativeWrapperContractEncoder);
-
-        TxBlock createNewNativeWrapperTx = TxBlock(
-          ProtocolContractAddresses.at("ContractManager"),
-          owner,
-          createNativeWrapperContractData,
-          8080,
-          currentNonce++,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        auto newBlock = createValidBlock(rdpos, storage, {createNewNativeWrapperTx});
-        state->processNextBlock(std::move(newBlock));
-
-        // Get the address of the new contract
-        contractAddress = state->getContracts()[0].second;
-
-        TxBlock depositTx = TxBlock(
-          contractAddress,
-          Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-          Hex::toBytes("0xd0e30db0"),
-          8080,
-          currentNonce++,
-          amountToTransfer,
-          1000000000,
-          1000000000,
-          21000,
-          ownerPrivKey
-        );
-
-        newBlock = createValidBlock(rdpos, storage, {depositTx});
-        state->processNextBlock(std::move(newBlock));
-
-        REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer);
-        REQUIRE(state->getNativeBalance(owner) == uint256_t("1000000000000000000000") - amountToTransfer - (uint256_t(1000000000) * 21000));
-
-        Bytes balanceOfEncoder = ABI::Encoder::encodeData(owner);
-        Functor balanceOfFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes balanceOfData = state->ethCall(buildCallInfo(contractAddress, balanceOfFunctor, balanceOfEncoder));
-
-        auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-        REQUIRE(std::get<0>(balanceOfDecoder) == amountToTransfer);
-
-      }
-      std::unique_ptr<DB> db;
-      std::unique_ptr<Storage> storage;
-      std::unique_ptr<P2P::ManagerNormal> p2p;
-      std::unique_ptr<rdPoS> rdpos;
-      std::unique_ptr<State> state;
-      std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                  testDumpPath + "/NativeWrapperDepositTest");
-
-      REQUIRE(contractAddress == state->getContracts()[0].second);
-      REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer);
-      REQUIRE(state->getNativeBalance(owner) == uint256_t("1000000000000000000000") - amountToTransfer - (uint256_t(1000000000) * 21000));
-
-      Bytes balanceOfEncoder = ABI::Encoder::encodeData(owner);
-      Functor balanceOfFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-      Bytes balanceOfData = state->ethCall(buildCallInfo(contractAddress, balanceOfFunctor, balanceOfEncoder));
-
-      auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-      REQUIRE(std::get<0>(balanceOfDecoder) == amountToTransfer);
-    }
-
-    SECTION("NativeWrapper Withdraw()") {
-      PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-      Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
-      Address contractAddress;
-      std::string tokenName = "WrappedToken";
-      std::string tokenSymbol = "WTKN";
-      uint256_t tokenDecimals = 18;
-      uint64_t currentNonce = 0;
+    SECTION("NativeWrapper deposit() and withdraw()") {
+      SDKTestSuite sdk("testNativeWrapperDepositAndWithdraw");
+      Address nativeWrapper = sdk.deployContract<NativeWrapper>(
+        std::string("WrappedToken"), std::string("WTKN"), uint8_t(18)
+      );
+      Address owner = sdk.getChainOwnerAccount().address;
       uint256_t amountToTransfer = uint256_t("192838158112259");
       uint256_t amountToWithdraw = amountToTransfer / 3;
-      {
-        std::unique_ptr<DB> db;
-        std::unique_ptr<Storage> storage;
-        std::unique_ptr<P2P::ManagerNormal> p2p;
-        std::unique_ptr<rdPoS> rdpos;
-        std::unique_ptr<State> state;
-        std::unique_ptr<Options> options;
-        initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, true,
-                    testDumpPath + "/NativeWrapperWithdrawTest");
-
-        // Create a new Contract
-        Bytes createNewNativeWrapperContractEncoder = ABI::Encoder::encodeData(tokenName, tokenSymbol, tokenDecimals);
-        Bytes createNativeWrapperContractData = Hex::toBytes("0xb296fad4");
-        Utils::appendBytes(createNativeWrapperContractData, createNewNativeWrapperContractEncoder);
-
-        TxBlock createNewNativeWrapperTx = TxBlock(
-          ProtocolContractAddresses.at("ContractManager"),
-          owner,
-          createNativeWrapperContractData,
-          8080,
-          currentNonce++,
-          0,
-          0,
-          0,
-          0,
-          ownerPrivKey
-        );
-
-        auto newBlock = createValidBlock(rdpos, storage, {createNewNativeWrapperTx});
-        state->processNextBlock(std::move(newBlock));
-
-        // Get the address of the new contract
-        contractAddress = state->getContracts()[0].second;
-
-        TxBlock depositTx = TxBlock(
-          contractAddress,
-          Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-          Hex::toBytes("0xd0e30db0"),
-          8080,
-          currentNonce++,
-          amountToTransfer,
-          1000000000,
-          1000000000,
-          21000,
-          ownerPrivKey
-        );
-
-        newBlock = createValidBlock(rdpos, storage, {depositTx});
-        state->processNextBlock(std::move(newBlock));
-
-        REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer);
-        REQUIRE(state->getNativeBalance(owner) ==
-                uint256_t("1000000000000000000000") - amountToTransfer - (uint256_t(1000000000) * 21000));
-
-        Bytes balanceOfEncoder = ABI::Encoder::encodeData(owner);
-        Functor balanceOfFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-        Bytes balanceOfData = state->ethCall(buildCallInfo(contractAddress, balanceOfFunctor, balanceOfEncoder));
-
-        auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-        REQUIRE(std::get<0>(balanceOfDecoder) == amountToTransfer);
-
-        Bytes withdrawEncoder = ABI::Encoder::encodeData(amountToWithdraw);
-        Bytes withdrawData = Hex::toBytes("0x2e1a7d4d");
-        Utils::appendBytes(withdrawData, withdrawEncoder);
-
-        TxBlock withdrawTx = TxBlock(
-          contractAddress,
-          Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-          withdrawData,
-          8080,
-          currentNonce++,
-          0,
-          1000000000,
-          1000000000,
-          21000,
-          ownerPrivKey
-        );
-
-        newBlock = createValidBlock(rdpos, storage, {withdrawTx});
-        state->processNextBlock(std::move(newBlock));
-
-        REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer - amountToWithdraw);
-        REQUIRE(state->getNativeBalance(owner) ==
-                uint256_t("1000000000000000000000") - amountToTransfer + amountToWithdraw - (uint256_t(1000000000) * 21000 * 2));
-
-        Bytes balanceOfEncoder2 = ABI::Encoder::encodeData(owner);
-        Functor balanceOfFunctor2 = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-        Bytes balanceOfData2 = state->ethCall(buildCallInfo(contractAddress, balanceOfFunctor2, balanceOfEncoder2));
-
-        auto balanceOfDecoder2 = ABI::Decoder::decodeData<uint256_t>(balanceOfData2);
-        REQUIRE(std::get<0>(balanceOfDecoder2) == amountToTransfer - amountToWithdraw);
-      }
-
-      std::unique_ptr<DB> db;
-      std::unique_ptr<Storage> storage;
-      std::unique_ptr<P2P::ManagerNormal> p2p;
-      std::unique_ptr<rdPoS> rdpos;
-      std::unique_ptr<State> state;
-      std::unique_ptr<Options> options;
-      initialize(db, storage, p2p, rdpos, state, options, validatorPrivKeys[0], 8080, false,
-                  testDumpPath + "/NativeWrapperWithdrawTest");
-
-      REQUIRE(contractAddress == state->getContracts()[0].second);
-      REQUIRE(state->getNativeBalance(contractAddress) == amountToTransfer - amountToWithdraw);
-      REQUIRE(state->getNativeBalance(owner) ==
-              uint256_t("1000000000000000000000") - amountToTransfer + amountToWithdraw - (uint256_t(1000000000) * 21000 * 2));
-
-      Bytes balanceOfEncoder = ABI::Encoder::encodeData(owner);
-      Functor balanceOfFunctor = ABI::FunctorEncoder::encode<Address>("balanceOf");
-
-      Bytes balanceOfData = state->ethCall(buildCallInfo(contractAddress, balanceOfFunctor, balanceOfEncoder));
-
-      auto balanceOfDecoder = ABI::Decoder::decodeData<uint256_t>(balanceOfData);
-      REQUIRE(std::get<0>(balanceOfDecoder) == amountToTransfer - amountToWithdraw);
-
-
+      Hash depositTx = sdk.callFunction(nativeWrapper, &NativeWrapper::deposit, amountToTransfer);
+      REQUIRE(sdk.getNativeBalance(nativeWrapper) == amountToTransfer);
+      // SDKTestSuite::createNewTx() is adding a tx fee of 21000 gwei, thus * 2 (or * 3 in the test below)
+      REQUIRE(sdk.getNativeBalance(owner) == uint256_t("1000000000000000000000") - amountToTransfer - (uint256_t(1000000000) * 21000 * 2));
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::balanceOf, owner) == amountToTransfer);
+      Hash withdrawTx = sdk.callFunction(nativeWrapper, &NativeWrapper::withdraw, amountToWithdraw);
+      REQUIRE(sdk.getNativeBalance(nativeWrapper) == amountToTransfer - amountToWithdraw);
+      REQUIRE(sdk.getNativeBalance(owner) == uint256_t("1000000000000000000000") - amountToTransfer + amountToWithdraw - (uint256_t(1000000000) * 21000 * 3));
+      REQUIRE(sdk.callViewFunction(nativeWrapper, &NativeWrapper::balanceOf, owner) == amountToTransfer - amountToWithdraw);
     }
   }
 }

--- a/tests/contract/simplecontract.cpp
+++ b/tests/contract/simplecontract.cpp
@@ -13,236 +13,47 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/contract/contractmanager.h"
 #include "../../src/contract/templates/simplecontract.h"
 
+#include "../sdktestsuite.hpp"
+
 #include <filesystem>
-
-// Forward Declaration.
-ethCallInfoAllocated buildCallInfo(const Address& addressToCall, const Functor& function, const Bytes& dataToCall);
-
-void initialize(
-  std::unique_ptr<Options>& options, std::unique_ptr<DB>& db,
-  std::unique_ptr<ContractManager>& contractManager,
-  const std::string& dbName,
-  const PrivKey& ownerPrivKey,
-  const std::string& name,
-  const uint256_t& value,
-  bool deleteDB = true
-) {
-  // Initialize parameters
-  if (deleteDB && std::filesystem::exists(dbName)) std::filesystem::remove_all(dbName);
-  options = std::make_unique<Options>(Options::fromFile(dbName));
-  db = std::make_unique<DB>(dbName);
-  std::unique_ptr<rdPoS> rdpos;
-  contractManager = std::make_unique<ContractManager>(nullptr, db, rdpos, options);
-  // Create the contract
-  if (deleteDB) {
-    Bytes createNewSimpleContractEncoder = ABI::Encoder::encodeData(name, value);
-    Bytes createNewSimpleContractData = Hex::toBytes("0x6de23252"); // createNewSimpleContractContract(string,uint256)
-    Utils::appendBytes(createNewSimpleContractData, createNewSimpleContractEncoder);
-    TxBlock createNewSimpleContractTx = TxBlock(
-      ProtocolContractAddresses.at("ContractManager"),
-      Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey)),
-      createNewSimpleContractData, 8080, 0, 0, 0, 0, 0, ownerPrivKey
-    );
-    contractManager->callContract(createNewSimpleContractTx);
-  }
-}
 
 namespace TSimpleContract {
   TEST_CASE("SimpleContract class", "[contract][simplecontract]") {
-    std::string testDumpPath = Utils::getTestDumpPath();
-    PrivKey ownerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
-    Address owner = Secp256k1::toAddress(Secp256k1::toUPub(ownerPrivKey));
     SECTION("SimpleContract creation") {
-      Address contractAddress;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        initialize(options, db, contractManager,
-          testDumpPath + "/SimpleContractCreationTest", ownerPrivKey, "TestName", 19283187581
-        );
-
-        // Get the contract address.
-        contractAddress = contractManager->getContracts()[0].second;
-
-        Bytes getNameEncoder = Bytes(32, 0);
-        Bytes getValueEncoder = Bytes(32, 0);
-
-        Functor getNameFunctor = ABI::FunctorEncoder::encode<void>("getName");
-        Functor getValueFunctor = ABI::FunctorEncoder::encode<void>("getValue");
-
-        Bytes nameData = contractManager->callContract(buildCallInfo(contractAddress, getNameFunctor, getNameEncoder));
-        Bytes valueData = contractManager->callContract(buildCallInfo(contractAddress, getValueFunctor, getValueEncoder));
-
-        auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-        auto valueDecoder = ABI::Decoder::decodeData<uint256_t>(valueData);
-
-        REQUIRE(std::get<0>(nameDecoder) == "TestName");
-        REQUIRE(std::get<0>(valueDecoder) == 19283187581);
-      }
-
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      initialize(options, db, contractManager,
-        testDumpPath + "/SimpleContractCreationTest", ownerPrivKey, "TestName", 19283187581, false
+      SDKTestSuite sdk("testSimpleContractCreation");
+      Address simpleContract = sdk.deployContract<SimpleContract>(
+        std::string("TestName"), uint256_t(19283187581)
       );
-
-      REQUIRE(contractAddress == contractManager->getContracts()[0].second);
-
-      Bytes getNameEncoder = Bytes(32, 0);
-      Bytes getValueEncoder = Bytes(32, 0);
-
-      Functor getNameFunctor = ABI::FunctorEncoder::encode<void>("getName");
-      Functor getValueFunctor = ABI::FunctorEncoder::encode<void>("getValue");
-
-      Bytes nameData = contractManager->callContract(buildCallInfo(contractAddress, getNameFunctor, getNameEncoder));
-      Bytes valueData = contractManager->callContract(buildCallInfo(contractAddress, getValueFunctor, getValueEncoder));
-
-      auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-      auto valueDecoder = ABI::Decoder::decodeData<uint256_t>(valueData);
-
-      REQUIRE(std::get<0>(nameDecoder) == "TestName");
-      REQUIRE(std::get<0>(valueDecoder) == 19283187581);
+      std::string name = sdk.callViewFunction(simpleContract, &SimpleContract::getName);
+      uint256_t value = sdk.callViewFunction(simpleContract, &SimpleContract::getValue);
+      REQUIRE(name == "TestName");
+      REQUIRE(value == 19283187581);
     }
 
     SECTION("SimpleContract setName and setValue") {
-      Address contractAddress;
-      {
-        std::unique_ptr<Options> options;
-        std::unique_ptr<DB> db;
-        std::unique_ptr<ContractManager> contractManager;
-        initialize(options, db, contractManager,
-          testDumpPath + "/SimpleContractSetNameAndSetValue", ownerPrivKey, "TestName", 19283187581
-        );
-
-        // Get the contract address.
-        contractAddress = contractManager->getContracts()[0].second;
-
-        Bytes getNameEncoder = Bytes(32, 0);
-        Bytes getValueEncoder = Bytes(32, 0);
-
-        Functor getNameFunctor = ABI::FunctorEncoder::encode<void>("getName");
-        Functor getValueFunctor = ABI::FunctorEncoder::encode<void>("getValue");
-
-        Bytes nameData = contractManager->callContract(buildCallInfo(contractAddress, getNameFunctor, getNameEncoder));
-        Bytes valueData = contractManager->callContract(buildCallInfo(contractAddress, getValueFunctor, getValueEncoder));
-
-        auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-        auto valueDecoder = ABI::Decoder::decodeData<uint256_t>(valueData);
-
-        Bytes setNameEncoder = ABI::Encoder::encodeData(std::string("TryThisName"));
-        Functor setNameFunctor = ABI::FunctorEncoder::encode<std::string>("setName");
-        Bytes setValueEncoder = ABI::Encoder::encodeData(uint256_t("918258172319061203818967178162134821351"));
-        Functor setValueFunctor = ABI::FunctorEncoder::encode<uint256_t>("setValue");
-
-        Bytes setNameBytes;
-        Utils::appendBytes(setNameBytes, setNameFunctor);
-        Utils::appendBytes(setNameBytes, setNameEncoder);
-
-        Bytes setValueBytes;
-        Utils::appendBytes(setValueBytes, setValueFunctor);
-        Utils::appendBytes(setValueBytes, setValueEncoder);
-
-        TxBlock setNameTx(contractAddress, owner, setNameBytes, 8080, 0, 0, 0, 0, 0, ownerPrivKey);
-        TxBlock setValueTx(contractAddress, owner, setValueBytes, 8080, 0, 0, 0, 0, 0, ownerPrivKey);
-
-        // Simulating a block so events can have separated keys (block height + tx index + log index).
-        Hash randomBlockHash = Hash::random();
-        contractManager->updateContractGlobals(Address(), randomBlockHash, 0, 0);
-        contractManager->callContract(setNameTx, randomBlockHash, 0);
-        contractManager->callContract(setValueTx, randomBlockHash, 1);
-
-        nameData = contractManager->callContract(buildCallInfo(contractAddress, getNameFunctor, getNameEncoder));
-        valueData = contractManager->callContract(buildCallInfo(contractAddress, getValueFunctor, getValueEncoder));
-
-        nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-        valueDecoder = ABI::Decoder::decodeData<uint256_t>(valueData);
-
-        REQUIRE(std::get<0>(nameDecoder) == "TryThisName");
-        REQUIRE(std::get<0>(valueDecoder) == uint256_t("918258172319061203818967178162134821351"));
-
-        Event nameEvent = contractManager->getEvents(
-          0, 1, contractAddress, { Utils::sha3(Utils::stringToBytes("nameChanged(string)")), Utils::sha3(Utils::stringToBytes("TryThisName")).asBytes() }
-        ).at(0);
-
-        REQUIRE(nameEvent.getName() == "nameChanged");
-        REQUIRE(nameEvent.getLogIndex() == 0);
-        std::cout << Hex::fromBytes(nameEvent.getTxHash().asBytes(), true).get() << std::endl;
-        std::cout << Hex::fromBytes(setNameTx.hash().asBytes(), true).get() << std::endl;
-        REQUIRE(nameEvent.getTxHash() == setNameTx.hash());
-        REQUIRE(nameEvent.getTxIndex() == 0);
-        REQUIRE(nameEvent.getBlockIndex() == 0);
-        REQUIRE(nameEvent.getAddress() == contractAddress);
-        REQUIRE(nameEvent.getData() == Bytes());
-        REQUIRE(nameEvent.getTopics().at(1) == Utils::sha3(Utils::stringToBytes("TryThisName"))); // at(0) = functor (non-anonymous)
-        REQUIRE(!nameEvent.isAnonymous());
-
-        Event valueEvent = contractManager->getEvents(
-          0, 1, contractAddress, { Utils::sha3(Utils::stringToBytes("valueChanged(uint256)")), Utils::padLeftBytes(Utils::uintToBytes(uint256_t("918258172319061203818967178162134821351")), 32) }
-        ).at(0);
-
-        REQUIRE(valueEvent.getName() == "valueChanged");
-        REQUIRE(valueEvent.getLogIndex() == 0);
-        REQUIRE(valueEvent.getTxHash() == setValueTx.hash());
-        REQUIRE(valueEvent.getTxIndex() == 1);
-        REQUIRE(valueEvent.getBlockIndex() == 0);
-        REQUIRE(valueEvent.getAddress() == contractAddress);
-        REQUIRE(valueEvent.getData() == Bytes());
-        REQUIRE(valueEvent.getTopics().at(1) == Utils::padLeftBytes(Utils::uintToBytes(uint256_t("918258172319061203818967178162134821351")), 32)); // at(0) = functor (non-anonymous)
-        REQUIRE(!valueEvent.isAnonymous());
-      }
-
-      std::unique_ptr<Options> options;
-      std::unique_ptr<DB> db;
-      std::unique_ptr<ContractManager> contractManager;
-      initialize(options, db, contractManager,
-        testDumpPath + "/SimpleContractSetNameAndSetValue", ownerPrivKey, "TestName", 19283187581, false
+      SDKTestSuite sdk("testSimpleContractSetNameAndSetValue");
+      Address simpleContract = sdk.deployContract<SimpleContract>(
+        std::string("TestName"), uint256_t(19283187581)
       );
 
-      REQUIRE(contractAddress == contractManager->getContracts()[0].second);
+      std::string name = sdk.callViewFunction(simpleContract, &SimpleContract::getName);
+      uint256_t value = sdk.callViewFunction(simpleContract, &SimpleContract::getValue);
+      REQUIRE(name == "TestName");
+      REQUIRE(value == 19283187581);
 
-      Bytes getNameEncoder = Bytes(32, 0);
-      Bytes getValueEncoder = Bytes(32, 0);
+      Hash nameTx = sdk.callFunction(simpleContract, &SimpleContract::setName, std::string("TryThisName"));
+      Hash valueTx = sdk.callFunction(simpleContract, &SimpleContract::setValue, uint256_t("918258172319061203818967178162134821351"));
+      name = sdk.callViewFunction(simpleContract, &SimpleContract::getName);
+      value = sdk.callViewFunction(simpleContract, &SimpleContract::getValue);
+      REQUIRE(name == "TryThisName");
+      REQUIRE(value == uint256_t("918258172319061203818967178162134821351"));
 
-      Functor getNameFunctor = ABI::FunctorEncoder::encode<void>("getName");
-      Functor getValueFunctor = ABI::FunctorEncoder::encode<void>("getValue");
+      auto nameEvent = sdk.getEventsEmittedByTx(nameTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("TryThisName")));
+      auto valueEvent = sdk.getEventsEmittedByTx(valueTx, &SimpleContract::valueChanged, std::make_tuple(EventParam<uint256_t, true>(uint256_t("918258172319061203818967178162134821351"))));
+      REQUIRE(nameEvent.size() == 1);
+      REQUIRE(valueEvent.size() == 1);
 
-      Bytes nameData = contractManager->callContract(buildCallInfo(contractAddress, getNameFunctor, getNameEncoder));
-      Bytes valueData = contractManager->callContract(buildCallInfo(contractAddress, getValueFunctor, getValueEncoder));
-
-      auto nameDecoder = ABI::Decoder::decodeData<std::string>(nameData);
-      auto valueDecoder = ABI::Decoder::decodeData<uint256_t>(valueData);
-
-      REQUIRE(std::get<0>(nameDecoder) == "TryThisName");
-      REQUIRE(std::get<0>(valueDecoder) == uint256_t("918258172319061203818967178162134821351"));
-
-      // No tx hash here but it was already tested before
-      Event nameEvent = contractManager->getEvents(
-        0, 1, contractAddress, { Utils::sha3(Utils::stringToBytes("nameChanged(string)")), Utils::sha3(Utils::stringToBytes("TryThisName")).asBytes() }
-      ).at(0);
-
-      REQUIRE(nameEvent.getName() == "nameChanged");
-      REQUIRE(nameEvent.getLogIndex() == 0);
-      REQUIRE(nameEvent.getTxIndex() == 0);
-      REQUIRE(nameEvent.getBlockIndex() == 0);
-      REQUIRE(nameEvent.getAddress() == contractAddress);
-      REQUIRE(nameEvent.getData() == Bytes());
-      REQUIRE(nameEvent.getTopics().at(1) == Utils::sha3(Utils::stringToBytes("TryThisName"))); // at(0) = functor (non-anonymous)
-      REQUIRE(!nameEvent.isAnonymous());
-
-      Event valueEvent = contractManager->getEvents(
-        0, 1, contractAddress, { Utils::sha3(Utils::stringToBytes("valueChanged(uint256)")), Utils::padLeftBytes(Utils::uintToBytes(uint256_t("918258172319061203818967178162134821351")), 32) }
-      ).at(0);
-
-      REQUIRE(valueEvent.getName() == "valueChanged");
-      REQUIRE(valueEvent.getLogIndex() == 0);
-      REQUIRE(valueEvent.getTxIndex() == 1);
-      REQUIRE(valueEvent.getBlockIndex() == 0);
-      REQUIRE(valueEvent.getAddress() == contractAddress);
-      REQUIRE(valueEvent.getData() == Bytes());
-      REQUIRE(valueEvent.getTopics().at(1) == Utils::padLeftBytes(Utils::uintToBytes(uint256_t("918258172319061203818967178162134821351")), 32)); // at(0) = functor (non-anonymous)
-      REQUIRE(!valueEvent.isAnonymous());
+      // TODO: maybe test the rest of the events?
     }
   }
 }

--- a/tests/contract/simplecontract.cpp
+++ b/tests/contract/simplecontract.cpp
@@ -168,6 +168,8 @@ namespace TSimpleContract {
 
         REQUIRE(nameEvent.getName() == "nameChanged");
         REQUIRE(nameEvent.getLogIndex() == 0);
+        std::cout << Hex::fromBytes(nameEvent.getTxHash().asBytes(), true).get() << std::endl;
+        std::cout << Hex::fromBytes(setNameTx.hash().asBytes(), true).get() << std::endl;
         REQUIRE(nameEvent.getTxHash() == setNameTx.hash());
         REQUIRE(nameEvent.getTxIndex() == 0);
         REQUIRE(nameEvent.getBlockIndex() == 0);

--- a/tests/contract/simplecontract.cpp
+++ b/tests/contract/simplecontract.cpp
@@ -48,8 +48,8 @@ namespace TSimpleContract {
       REQUIRE(name == "TryThisName");
       REQUIRE(value == uint256_t("918258172319061203818967178162134821351"));
 
-      auto nameEvent = sdk.getEventsEmittedByTx(nameTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, false>("TryThisName")));
-      auto valueEvent = sdk.getEventsEmittedByTx(valueTx, &SimpleContract::valueChanged, std::make_tuple(EventParam<uint256_t, true>(uint256_t("918258172319061203818967178162134821351"))));
+      auto nameEvent = sdk.getEventsEmittedByTx(nameTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("TryThisName")));
+      auto valueEvent = sdk.getEventsEmittedByTx(valueTx, &SimpleContract::valueChanged, std::make_tuple(EventParam<uint256_t, false>(uint256_t("918258172319061203818967178162134821351"))));
       REQUIRE(nameEvent.size() == 1);
       REQUIRE(valueEvent.size() == 1);
 

--- a/tests/contract/simplecontract.cpp
+++ b/tests/contract/simplecontract.cpp
@@ -48,7 +48,7 @@ namespace TSimpleContract {
       REQUIRE(name == "TryThisName");
       REQUIRE(value == uint256_t("918258172319061203818967178162134821351"));
 
-      auto nameEvent = sdk.getEventsEmittedByTx(nameTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("TryThisName")));
+      auto nameEvent = sdk.getEventsEmittedByTx(nameTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, false>("TryThisName")));
       auto valueEvent = sdk.getEventsEmittedByTx(valueTx, &SimpleContract::valueChanged, std::make_tuple(EventParam<uint256_t, true>(uint256_t("918258172319061203818967178162134821351"))));
       REQUIRE(nameEvent.size() == 1);
       REQUIRE(valueEvent.size() == 1);

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -1,6 +1,5 @@
 #include "sdktestsuite.hpp"
 
-
 #include "../../src/libs/catch2/catch_amalgamated.hpp"
 #include "../../src/contract/templates/erc20.h"
 #include "../../src/contract/templates/simplecontract.h"
@@ -70,18 +69,15 @@ namespace TSDKTestSuite {
     SECTION("SDK Test Suite getEvents") {
       SDKTestSuite sdkTestSuite("testSuiteGetEvents");
       auto simpleContractAddress = sdkTestSuite.deployContract<SimpleContract>(std::string("Hello World!"), uint256_t(10));
-
       auto changeNameAndValueTx = sdkTestSuite.callFunction(simpleContractAddress, &SimpleContract::setName, std::string("Hello World 2!"));
-
       auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
       REQUIRE(events.size() == 1);
-
       auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
       REQUIRE(filteredEvents.size() == 1);
-
       auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
       REQUIRE(filteredEvents2.size() == 0);
-
     }
   }
 }
+
+

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -1,0 +1,87 @@
+#include "sdktestsuite.hpp"
+
+
+#include "../../src/libs/catch2/catch_amalgamated.hpp"
+#include "../../src/contract/templates/erc20.h"
+#include "../../src/contract/templates/simplecontract.h"
+
+namespace TSDKTestSuite {
+  TEST_CASE("SDK Test Suite", "[sdktestsuite]") {
+    SECTION("SDK Test Suite Constructor") {
+      Address destinationOfTransfer = Address(Utils::randBytes(20));
+      SDKTestSuite sdkTestSuite("testSuitConstructor");
+      auto latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 0); // Genesis
+    }
+
+    SECTION("SDK Test Suite advanceChain") {
+      SDKTestSuite sdkTestSuite("testSuiteAdvanceChain");
+      auto latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 0); // Genesis
+      sdkTestSuite.advanceChain();
+      latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 1);
+    }
+
+    SECTION("SDK Test Suite Simple Transfer") {
+      Address destinationOfTransfer = Address(Utils::randBytes(20));
+      SDKTestSuite sdkTestSuite("testSuiteSimpleTransfer");
+      auto latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 0); // Genesis
+      sdkTestSuite.transfer(sdkTestSuite.getChainOwnerAccount(), destinationOfTransfer, 1000000000000000000);
+      latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 1);
+      REQUIRE(latestBlock->getTxs().size() == 1);
+      REQUIRE(sdkTestSuite.getNativeBalance(destinationOfTransfer) == 1000000000000000000);
+      REQUIRE(sdkTestSuite.getNativeBalance(sdkTestSuite.getChainOwnerAccount().address) < uint256_t("999000000000000000000")); // 1000 - 1 - fees
+    }
+
+    SECTION("SDK Test Suite Deploy Contract") {
+      SDKTestSuite sdkTestSuite("testSuiteDeployContract");
+      auto latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 0); // Genesis
+      Address newContract = sdkTestSuite.deployContract<ERC20>(std::string("ERC20"), std::string("ERC20"), uint8_t(18), uint256_t("1000000000000000000"));
+      latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 1);
+      REQUIRE(latestBlock->getTxs().size() == 1);
+      REQUIRE(newContract != Address());
+    }
+
+    SECTION("SDK Test Suite Deploy and Call Contract")
+    {
+      Address destinationOfTransfer = Address(Utils::randBytes(20));
+      SDKTestSuite sdkTestSuite("testSuiteDeployAndCall");
+      auto latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 0); // Genesis
+      Address newContract = sdkTestSuite.deployContract<ERC20>(std::string("ERC20"), std::string("ERC20"), uint8_t(18), uint256_t("1000000000000000000"));
+      latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 1);
+      REQUIRE(latestBlock->getTxs().size() == 1);
+      REQUIRE(newContract != Address());
+      REQUIRE(sdkTestSuite.callViewFunction(newContract, &ERC20::balanceOf, sdkTestSuite.getChainOwnerAccount().address) == uint256_t("1000000000000000000"));
+      Hash transferTx = sdkTestSuite.callFunction(newContract, &ERC20::transfer, destinationOfTransfer, uint256_t("10000000000000000"));
+      latestBlock = sdkTestSuite.getLatestBlock();
+      REQUIRE(latestBlock->getNHeight() == 2);
+      REQUIRE(latestBlock->getTxs().size() == 1);
+      REQUIRE(sdkTestSuite.callViewFunction(newContract, &ERC20::balanceOf, destinationOfTransfer) == uint256_t("10000000000000000"));
+      REQUIRE(sdkTestSuite.callViewFunction(newContract, &ERC20::balanceOf, sdkTestSuite.getChainOwnerAccount().address) == uint256_t("990000000000000000"));
+    }
+
+    SECTION("SDK Test Suite getEvents") {
+      SDKTestSuite sdkTestSuite("testSuiteGetEvents");
+      auto simpleContractAddress = sdkTestSuite.deployContract<SimpleContract>(std::string("Hello World!"), uint256_t(10));
+
+      auto changeNameAndValueTx = sdkTestSuite.callFunction(simpleContractAddress, &SimpleContract::setName, std::string("Hello World 2!"));
+
+      auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
+      REQUIRE(events.size() == 1);
+
+      auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      REQUIRE(filteredEvents.size() == 1);
+
+      auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
+      REQUIRE(filteredEvents2.size() == 0);
+
+    }
+  }
+}

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -4,7 +4,6 @@
 #include "../../src/contract/templates/erc20.h"
 #include "../../src/contract/templates/simplecontract.h"
 #include <tuple>
-
 namespace TSDKTestSuite {
   TEST_CASE("SDK Test Suite", "[sdktestsuite]") {
     SECTION("SDK Test Suite Constructor") {
@@ -81,9 +80,11 @@ namespace TSDKTestSuite {
       // REQUIRE(filteredEvents3.size() == 1);
       // auto tupple = sdkTestSuite.getEventsEmittedByTxTup(changeNameAndValueTx, &SimpleContract::nameChanged);
 
-      using KnownFunctionType = void(SimpleContract::*)(const EventParam<std::string, false>&);
+      using KnownFunctionType = void(SimpleContract::*)(const EventParam<std::string, false>&, const EventParam<std::string, false>&);
       using KnownTupleType = SDKTestSuite::FunctionTraits<KnownFunctionType>::TupleType;
+
       static_assert(!std::is_same_v<KnownTupleType, std::tuple<>>, "KnownTupleType should not be an empty tuple");
+      static_assert(std::is_same_v<KnownTupleType, std::tuple<std::string,std::string>>, "KnownTupleType should be a tuple of two strings");
 
     }
   }

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -78,7 +78,7 @@ namespace TSDKTestSuite {
       // REQUIRE(filteredEvents2.size() == 0);
       // auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
       // REQUIRE(filteredEvents3.size() == 1);
-      // auto tupple = sdkTestSuite.getEventsEmittedByTxTup(changeNameAndValueTx, &SimpleContract::nameChanged);
+      auto tupple = sdkTestSuite.getEventsEmittedByTxTup(changeNameAndValueTx, &SimpleContract::nameChanged);
 
       using KnownFunctionType = void(SimpleContract::*)(const EventParam<std::string, false>&, const EventParam<std::string, false>&);
       using KnownTupleType = SDKTestSuite::FunctionTraits<KnownFunctionType>::TupleType;

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -3,6 +3,7 @@
 #include "../../src/libs/catch2/catch_amalgamated.hpp"
 #include "../../src/contract/templates/erc20.h"
 #include "../../src/contract/templates/simplecontract.h"
+#include <tuple>
 
 namespace TSDKTestSuite {
   TEST_CASE("SDK Test Suite", "[sdktestsuite]") {
@@ -70,14 +71,20 @@ namespace TSDKTestSuite {
       SDKTestSuite sdkTestSuite("testSuiteGetEvents");
       auto simpleContractAddress = sdkTestSuite.deployContract<SimpleContract>(std::string("Hello World!"), uint256_t(10));
       auto changeNameAndValueTx = sdkTestSuite.callFunction(simpleContractAddress, &SimpleContract::setName, std::string("Hello World 2!"));
-      auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
-      REQUIRE(events.size() == 1);
-      auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
-      REQUIRE(filteredEvents.size() == 1);
-      auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
-      REQUIRE(filteredEvents2.size() == 0);
-      auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
-      REQUIRE(filteredEvents3.size() == 1);
+      // auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
+      // REQUIRE(events.size() == 1);
+      // auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      // REQUIRE(filteredEvents.size() == 1);
+      // auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
+      // REQUIRE(filteredEvents2.size() == 0);
+      // auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      // REQUIRE(filteredEvents3.size() == 1);
+      // auto tupple = sdkTestSuite.getEventsEmittedByTxTup(changeNameAndValueTx, &SimpleContract::nameChanged);
+
+      using KnownFunctionType = void(SimpleContract::*)(const EventParam<std::string, false>&);
+      using KnownTupleType = SDKTestSuite::FunctionTraits<KnownFunctionType>::TupleType;
+      static_assert(!std::is_same_v<KnownTupleType, std::tuple<>>, "KnownTupleType should not be an empty tuple");
+
     }
   }
 }

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -4,6 +4,7 @@
 #include "../../src/contract/templates/erc20.h"
 #include "../../src/contract/templates/simplecontract.h"
 #include <tuple>
+
 namespace TSDKTestSuite {
   TEST_CASE("SDK Test Suite", "[sdktestsuite]") {
     SECTION("SDK Test Suite Constructor") {
@@ -70,21 +71,21 @@ namespace TSDKTestSuite {
       SDKTestSuite sdkTestSuite("testSuiteGetEvents");
       auto simpleContractAddress = sdkTestSuite.deployContract<SimpleContract>(std::string("Hello World!"), uint256_t(10));
       auto changeNameAndValueTx = sdkTestSuite.callFunction(simpleContractAddress, &SimpleContract::setName, std::string("Hello World 2!"));
-      // auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
-      // REQUIRE(events.size() == 1);
-      // auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
-      // REQUIRE(filteredEvents.size() == 1);
-      // auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
-      // REQUIRE(filteredEvents2.size() == 0);
-      // auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
-      // REQUIRE(filteredEvents3.size() == 1);
-      auto tupple = sdkTestSuite.getEventsEmittedByTxTup(changeNameAndValueTx, &SimpleContract::nameChanged);
+      auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
+      REQUIRE(events.size() == 1);
+      auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      REQUIRE(filteredEvents.size() == 1);
+      auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
+      REQUIRE(filteredEvents2.size() == 0);
+      auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      REQUIRE(filteredEvents3.size() == 1);
 
-      using KnownFunctionType = void(SimpleContract::*)(const EventParam<std::string, false>&, const EventParam<std::string, false>&);
-      using KnownTupleType = SDKTestSuite::FunctionTraits<KnownFunctionType>::TupleType;
-
-      static_assert(!std::is_same_v<KnownTupleType, std::tuple<>>, "KnownTupleType should not be an empty tuple");
-      static_assert(std::is_same_v<KnownTupleType, std::tuple<std::string,std::string>>, "KnownTupleType should be a tuple of two strings");
+      auto changeValueTx = sdkTestSuite.callFunction(simpleContractAddress, &SimpleContract::setValue, uint256_t(20));
+      auto tupleVec = sdkTestSuite.getEventsEmittedByTxTup(changeValueTx, &SimpleContract::valueChanged);
+      REQUIRE(tupleVec.size() == 1);
+      for (auto& tuple : tupleVec) {
+        REQUIRE(std::get<0>(tuple) == uint256_t(20));
+      }
 
     }
   }

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -76,6 +76,8 @@ namespace TSDKTestSuite {
       REQUIRE(filteredEvents.size() == 1);
       auto filteredEvents2 = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 3!")));
       REQUIRE(filteredEvents2.size() == 0);
+      auto filteredEvents3 = sdkTestSuite.getEventsEmittedByAddress(simpleContractAddress, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
+      REQUIRE(filteredEvents3.size() == 1);
     }
   }
 }

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -804,7 +804,7 @@ class SDKTestSuite {
       template <typename TContract, typename... Args, bool... Flags>
       struct FunctionTraits<void(TContract::*)(const EventParam<Args, Flags>&...)>
       {
-          using TupleType = decltype(ABI::Decoder::makeTupleType<Args..., std::integral_constant<bool, Flags>...>());
+          using TupleType = typename ABI::Decoder::makeTupleType<EventParam<Args, Flags>...>::type;
       };
 
     template <typename TContract, typename... Args, bool... Flags>

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -600,7 +600,7 @@ class SDKTestSuite {
       toInfo = contractAddress;
       functorInfo = ABI::FunctorEncoder::encode<>(ContractReflectionInterface::getFunctionName(func));
       dataInfo = Bytes();
-      return ABI::Decoder::decodeData<ReturnType>(this->state_->ethCall(callData));
+      return std::get<0>(ABI::Decoder::decodeData<ReturnType>(this->state_->ethCall(callData)));
     }
 
     /**

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -1,0 +1,825 @@
+/*
+Copyright (c) [2023] [Sparq Network]
+
+This software is distributed under the MIT License.
+See the LICENSE.txt file in the project root for more information.
+*/
+
+#ifndef SDKTESTSUITE_H
+#define SDKTESTSUITE_H
+
+#include "../src/core/storage.h"
+#include "../src/core/rdpos.h"
+#include "../src/core/state.h"
+#include "../src/net/p2p/managernormal.h"
+#include "../src/net/http/httpserver.h"
+#include "../src/utils/options.h"
+#include "../src/utils/db.h"
+#include "../src/core/blockchain.h"
+
+
+/**
+ * Struct for accounts used within the SDKTestSuite
+ * A simple wrapper around a private key and its corresponding address.
+ */
+struct TestAccount {
+  /// Private key of the account.
+  const PrivKey privKey;
+  /// Address of the account.
+  const Address address;
+  /// Empty Account constructor.
+  TestAccount() = default;
+  /// Account constructor.
+  /// @param privKey_ Private key of the account.
+  TestAccount(const PrivKey& privKey_) : privKey(privKey_), address(Secp256k1::toAddress(Secp256k1::toPub(privKey))) {}
+  /// Create a new random account.
+  /// @return A new random account.
+  static TestAccount newRandomAccount() {
+    return TestAccount(Utils::randBytes(32));
+  }
+  /// Operator bool to check if the account is not default, use PrivKey::operator bool.
+  explicit operator bool() const { return bool(this->privKey); }
+};
+
+class SDKTestSuite {
+  private:
+    std::unique_ptr<Options> options_; ///< Pointer to the options singleton.
+    std::unique_ptr<DB> db_; ///< Pointer to the database.
+    std::unique_ptr<Storage> storage_; ///< Pointer to the blockchain storage.
+    std::unique_ptr<State> state_; ///< Pointer to the blockchain state.
+    std::unique_ptr<rdPoS> rdpos_; ///< Pointer to the rdPoS object (consensus).
+    std::unique_ptr<P2P::ManagerNormal> p2p_; ///< Pointer to the P2P connection manager.
+    std::unique_ptr<HTTPServer> http_; ///< Pointer to the HTTP server.
+    const TestAccount chainOwnerAccount_ = TestAccount(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867")); ///< Owner of the chain. (0x00dead00...)
+
+    /// PrivateKeys of the validators for the rdPoS within SDKTestSuite
+    const std::vector<PrivKey> validatorPrivKeys_ {
+      PrivKey(Hex::toBytes("0x0a0415d68a5ec2df57aab65efc2a7231b59b029bae7ff1bd2e40df9af96418c8")),
+      PrivKey(Hex::toBytes("0xb254f12b4ca3f0120f305cabf1188fe74f0bd38e58c932a3df79c4c55df8fa66")),
+      PrivKey(Hex::toBytes("0x8a52bb289198f0bcf141688a8a899bf1f04a02b003a8b1aa3672b193ce7930da")),
+      PrivKey(Hex::toBytes("0x9048f5e80549e244b7899e85a4ef69512d7d68613a3dba828266736a580e7745")),
+      PrivKey(Hex::toBytes("0x0b6f5ad26f6eb79116da8c98bed5f3ed12c020611777d4de94c3c23b9a03f739")),
+      PrivKey(Hex::toBytes("0xa69eb3a3a679e7e4f6a49fb183fb2819b7ab62f41c341e2e2cc6288ee22fbdc7")),
+      PrivKey(Hex::toBytes("0xd9b0613b7e4ccdb0f3a5ab0956edeb210d678db306ab6fae1e2b0c9ebca1c2c5")),
+      PrivKey(Hex::toBytes("0x426dc06373b694d8804d634a0fd133be18e4e9bcbdde099fce0ccf3cb965492f"))
+    };
+  public:
+    /**
+     * Initialize all components of a full blockchain node.
+     * @param sdkPath Path to the SDK folder.
+     * @param accounts (optional) List of accounts to initialize the blockchain with.
+     * @param options (optional) Options to initialize the blockchain with.
+     */
+    SDKTestSuite(const std::string& sdkPath,
+                 const std::vector<TestAccount>& accounts = {},
+                 const std::unique_ptr<Options>& options = nullptr) {
+      // Initialize the DB
+      std::string dbPath = sdkPath + "/db";
+      if (std::filesystem::exists(dbPath)) {
+        std::filesystem::remove_all(dbPath);
+      }
+      this->db_ = std::make_unique<DB>(dbPath);
+
+      // Create the initial blockchain information (genesis block) and fill DB with it.
+      // Genesis Keys:
+      // Private: 0xe89ef6409c467285bcae9f80ab1cfeb348  Hash(Hex::toBytes("0x0a0415d68a5ec2df57aab65efc2a7231b59b029bae7ff1bd2e40df9af96418c8")),7cfe61ab28fb7d36443e1daa0c2867
+      // Address: 0x00dead00665771855a34155f5e7405489df2c3c6
+      Block genesis(Hash(Utils::uint256ToBytes(0)), 1678887537000000, 0);
+      genesis.finalize(PrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867")), 1678887538000000);
+      this->db_->put(Utils::stringToBytes("latest"), genesis.serializeBlock(), DBPrefix::blocks);
+      this->db_->put(Utils::uint64ToBytes(genesis.getNHeight()), genesis.hash().get(), DBPrefix::blockHeightMaps);
+      this->db_->put(genesis.hash().get(), genesis.serializeBlock(), DBPrefix::blocks);
+
+      // Populate rdPoS DB with unique rdPoS, not default.
+      for (uint64_t i = 0; i < this->validatorPrivKeys_.size(); ++i) {
+        this->db_->put(Utils::uint64ToBytes(i), Address(Secp256k1::toAddress(Secp256k1::toUPub(this->validatorPrivKeys_[i]))).get(),
+                DBPrefix::rdPoS);
+      }
+
+      // Fill initial accounts with some funds.
+      // Populate State DB with one address.
+      // Initialize with chain owner account.
+      // See ~State for encoding
+      const uint256_t desiredBalance("1000000000000000000000");
+      {
+        Bytes value = Utils::uintToBytes(Utils::bytesRequired(desiredBalance));
+        Utils::appendBytes(value, Utils::uintToBytes(desiredBalance));
+        value.insert(value.end(), 0x00);
+        this->db_->put(this->chainOwnerAccount_.address.get(), value, DBPrefix::nativeAccounts);
+      }
+      // Populate the remaining accounts.
+      for (const TestAccount& account : accounts) {
+        Bytes value = Utils::uintToBytes(Utils::bytesRequired(desiredBalance));
+        Utils::appendBytes(value, Utils::uintToBytes(desiredBalance));
+        value.insert(value.end(), 0x00);
+        this->db_->put(account.address.get(), value, DBPrefix::nativeAccounts);
+      }
+      // Create a default options if none is provided.
+      if (options == nullptr) {
+        std::vector<std::pair<boost::asio::ip::address, uint64_t>> discoveryNodes;
+        this->options_ = std::make_unique<Options>(
+          sdkPath,
+          "OrbiterSDK/cpp/linux_x86-64/0.1.2",
+          1,
+          8080,
+          8080,
+          9999,
+          discoveryNodes
+        );
+      } else {
+        this->options_ = std::make_unique<Options>(*options);
+      }
+      this->storage_ = std::make_unique<Storage>(db_, options_);
+      this->rdpos_ = std::make_unique<rdPoS>(db_, storage_, p2p_, options_, state_);
+      this->state_ = std::make_unique<State>(db_, storage_, rdpos_, p2p_, options_);
+      this->p2p_ = std::make_unique<P2P::ManagerNormal>(boost::asio::ip::address::from_string("127.0.0.1"), rdpos_, options_, storage_, state_);
+      this->http_ = std::make_unique<HTTPServer>(state_, storage_, p2p_, options_);
+    }
+
+    /**
+     * Get a block using its hash
+     * @param hash Hash of the block to get.
+     * @return A pointer to the block. nullptr if not found.
+     */
+    const std::shared_ptr<const Block> getBlock(const Hash& hash) const {
+      return this->storage_->getBlock(hash);
+    }
+
+    /**
+     * Get a block using its height
+     * @param height Height of the block to get.
+     * @return A pointer to the block. nullptr if not found.
+     */
+    const std::shared_ptr<const Block> getBlock(const uint64_t height) const {
+      return this->storage_->getBlock(height);
+    }
+
+    /**
+     * Create a new valid block, finalize it, and add it to the chain.
+     * Returns a pointer to the new block.
+     * @param timestamp (optional) Timestamp to use for the block in microseconds.
+     * @param txs (optional) List of transactions to include in the block.
+     */
+    const std::shared_ptr<const Block> advanceChain(const uint64_t& timestamp = 0, const std::vector<TxBlock>& txs = {}) {
+      auto validators = rdpos_->getValidators();
+      auto randomList = rdpos_->getRandomList();
+      Hash blockSignerPrivKey;           // Private key for the block signer.
+      std::vector<Hash> orderedPrivKeys; // Private keys for the rdPoS in the order of the random list, limited to rdPoS::minValidators.
+      orderedPrivKeys.reserve(4);
+      for (const auto& privKey : this->validatorPrivKeys_) {
+        if (Secp256k1::toAddress(Secp256k1::toUPub(privKey)) == randomList[0]) {
+          blockSignerPrivKey = privKey;
+          break;
+        }
+      }
+
+      for (uint64_t i = 1; i < rdPoS::minValidators + 1; i++) {
+        for (const auto& privKey : this->validatorPrivKeys_) {
+          if (Secp256k1::toAddress(Secp256k1::toUPub(privKey)) == randomList[i]) {
+            orderedPrivKeys.push_back(privKey);
+            break;
+          }
+        }
+      }
+
+      // By now we should have randomList[0] privKey in blockSignerPrivKey and the rest in orderedPrivKeys, ordered by the random list.
+      // We can proceed with creating the block, transactions have to be **ordered** by the random list.
+
+      // Create a block with 8 TxValidator transactions, 2 for each validator, in order (randomHash and random)
+      uint64_t newBlocknHeight = this->storage_->latest()->getNHeight() + 1;
+      uint64_t newBlockTimestamp = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+      Hash newBlockPrevHash = this->storage_->latest()->hash();
+      Block newBlock(newBlockPrevHash, newBlockTimestamp, newBlocknHeight);
+      std::vector<TxValidator> randomHashTxs;
+      std::vector<TxValidator> randomTxs;
+
+      std::vector<Hash> randomSeeds(orderedPrivKeys.size(), Hash::random());
+      for (uint64_t i = 0; i < orderedPrivKeys.size(); ++i) {
+        Address validatorAddress = Secp256k1::toAddress(Secp256k1::toUPub(orderedPrivKeys[i]));
+        Bytes hashTxData = Hex::toBytes("0xcfffe746");
+        Utils::appendBytes(hashTxData, Utils::sha3(randomSeeds[i].get()));
+        Bytes randomTxData = Hex::toBytes("0x6fc5a2d6");
+        Utils::appendBytes(randomTxData, randomSeeds[i].get());
+        randomHashTxs.emplace_back(
+          validatorAddress,
+          hashTxData,
+          8080,
+          newBlocknHeight,
+          orderedPrivKeys[i]
+        );
+        randomTxs.emplace_back(
+          validatorAddress,
+          randomTxData,
+          8080,
+          newBlocknHeight,
+          orderedPrivKeys[i]
+        );
+      }
+      // Append the transactions to the block.
+      for (const auto& tx : randomHashTxs) {
+        this->rdpos_->addValidatorTx(tx);
+        newBlock.appendTxValidator(tx);
+      }
+      for (const auto& tx : randomTxs) {
+        this->rdpos_->addValidatorTx(tx);
+        newBlock.appendTxValidator(tx);
+      }
+      for (const auto& tx : txs) {
+        newBlock.appendTx(tx);
+      }
+
+      // Finalize the block
+      if (timestamp == 0) {
+        newBlock.finalize(blockSignerPrivKey, std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count());
+      } else {
+        newBlock.finalize(blockSignerPrivKey, timestamp);
+      }
+
+      // After finalization, the block should be valid.
+      if (!this->state_->validateNextBlock(newBlock)) {
+        throw std::runtime_error("SDKTestSuite::advanceBlock: Block is not valid");
+      }
+      // Process the block
+      state_->processNextBlock(std::move(newBlock));
+      return this->storage_->latest();
+    }
+
+    /**
+     * Creates a new TxBlock object based on the provided account and given the current state (for nonce)
+     * @param TestAccount from Account to send from. (the private key to sign the transaction will be taken from here)
+     * @param Address to Address to send to.
+     * @param uint256_t value Amount to send.
+     * @param Bytes (optional) data Data to send.
+     */
+    TxBlock createNewTx(const TestAccount& from, const Address& to, const uint256_t& value, Bytes data = Bytes()) {
+      return TxBlock(to,
+                 from.address,
+                 data,
+                 this->options_->getChainID(),
+                 this->state_->getNativeNonce(from.address),
+                 value,
+                 1000000000, // 1 GWEI
+                 1000000000, // 1 GWEI
+                 21000,
+                 from.privKey);
+    }
+
+    /**
+     * Make a simple transfer transaction and advance the chain with it.
+     * @param from Account to send from. (the private key to sign the transaction will be taken from here)
+     * @param to Address to send to.
+     * @param value Amount to send.
+     * @return
+     */
+    const Hash transfer(const TestAccount& from, const Address& to, const uint256_t& value) {
+      TxBlock tx = createNewTx(from, to, value);
+      this->advanceChain(0, {tx});
+      return tx.hash();
+    }
+
+    /**
+     * Get all events emitted under a given transaction.
+     * @param txHash The hash of the transaction to look for events.
+     * @return a vector of events emitted by the transaction.
+     */
+    const std::vector<Event> getEvents(const Hash& tx) const {
+      auto txBlock = this->storage_->getTx(tx);
+      return this->state_->getEvents(std::get<0>(txBlock)->hash(), std::get<3>(txBlock), std::get<2>(txBlock));
+    }
+
+    /**
+     * Get the latest accepted block
+     * @return A pointer to the latest accepted block.
+     */
+    const std::shared_ptr<const Block> getLatestBlock() const {
+      return this->storage_->latest();
+    }
+
+    /**
+     * Get a transaction from the chain using a given hash.
+     * @param tx The transaction hash to get.
+     * @return A tuple with the found transaction, block hash, index and height, nullptr if the tx was not found
+     * @throw std::runtime_error on hash mismatch (should never happen).
+     */
+    const std::tuple<
+      const std::shared_ptr<const TxBlock>, const Hash, const uint64_t, const uint64_t
+    > getTx(const Hash& tx) {
+      return this->storage_->getTx(tx);
+    }
+
+    /**
+     * Create a transaction to deploy a new contract and advance the chain with it.
+     * Always use the chain owner account to deploy contracts.s
+     * @tparam TContract Contract type to deploy.
+     * @tparam Args... Arguments to pass to the contract constructor.
+     * @return Address of the deployed contract.
+     */
+    template <typename TContract, typename ...Args>
+    const Address deployContract(Args&&... args) {
+      TContract::registerContract();
+      auto prevContractList = this->state_->getContracts();
+      using ContractArgumentTypes = decltype(Utils::removeQualifiers<typename TContract::ConstructorArguments>());
+
+      static_assert(std::is_same_v<ContractArgumentTypes, std::tuple<std::decay_t<Args>...>>, "Invalid contract constructor arguments");
+      // Encode the functor
+      std::string createSignature = "createNew" + Utils::getRealTypeName<TContract>() + "Contract(";
+      createSignature += ContractReflectionInterface::getConstructorArgumentTypesString<TContract>();
+      createSignature += ")";
+      Functor functor = Utils::sha3(Utils::create_view_span(createSignature)).view_const(0, 4);
+      Bytes data(functor.cbegin(), functor.cend());
+      // Encode the arguments
+      if (sizeof...(args) > 0)
+        Utils::appendBytes(data, ABI::Encoder::encodeData<Args...>(std::forward<decltype(args)>(args)...));
+
+      // Create the transaction and advance the chain with it.
+      TxBlock createContractTx = createNewTx(this->chainOwnerAccount_, ProtocolContractAddresses.at("ContractManager"), 0, data);
+
+      this->advanceChain(0, {createContractTx});
+
+      // Return the new contract address.
+      auto newContractList = this->state_->getContracts();
+
+      // Filter new contract list to find the new contract.
+      // TODO: We are assuming that only one contract of the same type is deployed at a time.
+      // We need to somehow link a transaction to a newly created contract.
+      // This can also be used on eth_getTransactionReceipt contractAddress field.
+      Address newContractAddress;
+      for (const auto& contract : newContractList) {
+        if (std::find(prevContractList.begin(), prevContractList.end(), contract) == prevContractList.end()) {
+          newContractAddress = contract.second;
+          break;
+        }
+      }
+      return newContractAddress;
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function withous args
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @param contractAddress Address of the contract to call.
+     * @param func Function to call.
+     * @param value (optional) Value to send with the transaction.
+     * @param testAccount (optional) Account to send the transaction from.
+     * @param timestamp (optional) Timestamp to use for the transaction in microseconds.
+     */
+    template <typename R, typename TContract>
+    const Hash callFunction(const Address& contractAddress,
+                        R(TContract::*func)(),
+                        const uint256_t& value = 0,
+                        const TestAccount& testAccount = TestAccount(),
+                        const uint64_t& timestamp = 0) {
+      /// Create the transaction data
+      Hash ret;
+      Functor txFunctor = ABI::FunctorEncoder::encode<>(ContractReflectionInterface::getFunctionName(func));
+      Bytes txData(txFunctor.cbegin(), txFunctor.cend());
+      if (!testAccount) {
+        // Use the chain owner account if no account is provided.
+        TxBlock tx = this->createNewTx(
+            this->getChainOwnerAccount(),
+            contractAddress,
+            value,
+            txData
+          );
+        ret = tx.hash();
+        this->advanceChain(timestamp, {tx});
+      } else {
+        TxBlock tx = this->createNewTx(
+            testAccount,
+            contractAddress,
+            value,
+            txData
+          );
+        ret = tx.hash();
+        this->advanceChain(timestamp, {tx});
+      }
+      return ret;
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args
+     * We are not able to set default values like in the other specialization because of the variadic template.
+     * Therefore we need functions with no value/testAccount/timestamp parameters.
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param value Value to send with the transaction.
+     * @param testAccount Account to send the transaction from.
+     * @param timestamp Timestamp to use for the transaction in microseconds.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                            const uint256_t& value,
+                            const TestAccount& testAccount,
+                            const uint64_t& timestamp,
+                            R(TContract::*func)(const Args&...),
+                            const Args&... args) {
+      /// Create the transaction data
+      Hash ret;
+      Functor txFunctor = ABI::FunctorEncoder::encode<Args...>(ContractReflectionInterface::getFunctionName(func));
+      Bytes txData(txFunctor.cbegin(), txFunctor.cend());
+      Utils::appendBytes(txData, ABI::Encoder::encodeData<Args...>(std::forward<decltype(args)>(args)...));
+      if (!testAccount) {
+        // Use the chain owner account if no account is provided.
+        TxBlock tx = this->createNewTx(
+            this->getChainOwnerAccount(),
+            contractAddress,
+            value,
+            txData
+          );
+        ret = tx.hash();
+        this->advanceChain(timestamp, {tx});
+      } else {
+        TxBlock tx = this->createNewTx(
+      this->getChainOwnerAccount(),
+          contractAddress,
+          value,
+        txData
+        );
+        ret = tx.hash();
+        this->advanceChain(timestamp, {tx});
+      }
+      return ret;
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with no value/testAccount/timestamp parameters.
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, 0, this->getChainOwnerAccount(), 0, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with only value parameter
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param value Value to send with the transaction.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          uint256_t value,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, value, this->getChainOwnerAccount(), 0, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with only testAccount
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param testAccount Value to send with the transaction.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                        const TestAccount& testAccount,
+                        R(TContract::*func)(const Args&...),
+                        const Args&... args) {
+      return this->callFunction(contractAddress, 0, testAccount, 0, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with only timestamp parameter
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param timestamp Timestamp to use for the block in microseconds.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          uint64_t timestamp,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, 0, this->getChainOwnerAccount(), timestamp, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with value and testAccount parameters
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param value Value to send with the transaction.
+     * @param testAccount Account to send the transaction from.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          uint256_t value,
+                          const TestAccount& testAccount,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, value, testAccount, 0, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with value and timestamp parameters
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param value Value to send with the transaction.
+     * @param timestamp Timestamp to use for the block in microseconds.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          uint256_t value,
+                          uint64_t timestamp,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, value, this->getChainOwnerAccount(), timestamp, func, std::forward<decltype(args)>(args)...);
+    }
+
+
+    /**
+     * Create a transaction to call a contract function and advance the chain with it.
+     * Specialization for function with args with value and timestamp parameters
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param testAccount Account to send the transaction from.
+     * @param timestamp Timestamp to use for the block in microseconds.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const Hash callFunction(const Address& contractAddress,
+                          const TestAccount& testAccount,
+                          uint64_t timestamp,
+                          R(TContract::*func)(const Args&...),
+                          const Args&... args) {
+      return this->callFunction(contractAddress, 0, testAccount, timestamp, func, std::forward<decltype(args)>(args)...);
+    }
+
+    /**
+     * Call a contract view function with no args and return the result.
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @param contractAddress Address of the contract to call.
+     * @param func Function to call.
+     * @return The result of the function call. (R)
+     */
+    template <typename R, typename TContract>
+    const R callViewFunction(const Address& contractAddress,
+                             R(TContract::*func)() const) {
+      /// Create the call data
+      ethCallInfoAllocated callData;
+      auto& [fromInfo, toInfo, gasInfo, gasPriceInfo, valueInfo, functorInfo, dataInfo] = callData;
+
+      toInfo = contractAddress;
+      functorInfo = ABI::FunctorEncoder::encode<>(ContractReflectionInterface::getFunctionName(func));
+      dataInfo = Bytes();
+
+      return ABI::Decoder::decodeData<R>(this->state_->ethCall(callData));
+    }
+
+    /**
+     * Call a contract view function with args and return the result.
+     * @tparam R Return type of the function.
+     * @tparam TContract Contract type to call.
+     * @tparam Args... Arguments to pass to the function.
+     * @param contractAddress Address of the contract to call.
+     * @param func Function to call.
+     * @param args Arguments to pass to the function.
+     * @return The result of the function call. (R)
+     */
+    template <typename R, typename TContract, typename ...Args>
+    const R callViewFunction(const Address& contractAddress,
+                             R(TContract::*func)(const Args&...) const,
+                             const Args&... args) {
+      TContract::registerContract();
+      /// Create the call data
+      ethCallInfoAllocated callData;
+      auto& [fromInfo, toInfo, gasInfo, gasPriceInfo, valueInfo, functorInfo, dataInfo] = callData;
+
+      toInfo = contractAddress;
+      functorInfo = ABI::FunctorEncoder::encode<Args...>(ContractReflectionInterface::getFunctionName(func));
+      dataInfo = ABI::Encoder::encodeData<Args...>(std::forward<decltype(args)>(args)...);
+
+      return std::get<0>(ABI::Decoder::decodeData<R>(this->state_->ethCall(callData)));
+    }
+
+    /**
+     * Get all the events emitted under the given inputs.
+     * @param fromBlock The initial block height to look for.
+     * @param toBlock The final block height to look for.
+     * @param address The address to look for. If empty, will look for all available addresses.
+     * @param topics The topics to filter by. If empty, will look for all available topics.
+     * @return A list of matching events, limited by the block and/or log caps set above.
+     */
+    std::vector<Event> getEvents(
+      const uint64_t& fromBlock, const uint64_t& toBlock,
+      const Address& address, const std::vector<Hash>& topics
+    ) { return this->state_->getEvents(fromBlock, toBlock, address, topics); }
+
+    /**
+     * Overload of getEvents() used by "eth_getTransactionReceipts", where
+     * parameters are filtered differently (by exact tx, not a range).
+     * @param txHash The hash of the transaction to look for events.
+     * @param blockIndex The height of the block to look for events.
+     * @param txIndex The index of the transaction to look for events.
+     * @return A list of matching events, limited by the block and/or log caps set above.
+     */
+    std::vector<Event> getEvents(
+      const Hash& txHash, const uint64_t& blockIndex, const uint64_t& txIndex
+    ) { return this->state_->getEvents(txHash, blockIndex, txIndex); }
+
+    /**
+     * Get all events emitted by a given confirmed transaction.
+     * @param txHash The hash of the transaction to look for events.
+     */
+    std::vector<Event> getEvents(const Hash& txHash) {
+      auto tx = this->storage_->getTx(txHash);
+      return this->state_->getEvents(std::get<0>(tx)->hash(), std::get<3>(tx), std::get<2>(tx));
+    }
+
+    /**
+     * Get a specific event emitted by a given confirmed transaction.
+     * Specialization without args (will not filter indexed args)
+     * @tparam TContract Contract type to look for.
+     * @tparam Args... Arguments to pass to the EventParam.
+     * @tparam Flags... Flags to pass to the EventParam.
+     * @param txHash The hash of the transaction to look for events.
+     * @param func The function to look for.
+     * @param anonymous (optional) Whether the event is anonymous or not.
+     */
+    template <typename TContract, typename... Args, bool... Flags>
+    std::vector<Event> getEventsEmittedByTx(const Hash& txHash,
+                                           void(TContract::*func)(const EventParam<Args, Flags>&...),
+                                           bool anonymous = false) {
+      /// Get all the events emitted by the transaction.
+      auto eventSignature = ABI::EventEncoder::encodeSignature<Args...>(ContractReflectionInterface::getFunctionName(func));
+      std::vector<Hash> topicsToFilter;
+      if (!anonymous) {
+        topicsToFilter.push_back(eventSignature);
+      }
+
+      std::vector<Event> filteredEvents;
+      auto allEvents =  this->getEvents(txHash);
+
+      /// Filter the events by the topics
+      for (const auto& event : allEvents) {
+        if (topicsToFilter.size() == 0) {
+          filteredEvents.push_back(event);
+        } else {
+          if (event.getTopics().size() < topicsToFilter.size()) {
+            continue;
+          }
+          bool match = true;
+          for (uint64_t i = 0; i < topicsToFilter.size(); ++i) {
+            if (topicsToFilter[i] != event.getTopics()[i]) {
+              match = false;
+              break;
+            }
+          }
+          if (match) {
+            filteredEvents.push_back(event);
+          }
+        }
+      }
+      return filteredEvents;
+    }
+
+    /**
+     * Get a specific event emitted by a given confirmed transaction.
+     * Specialization with args (topics)
+     * @tparam TContract Contract type to look for.
+     * @tparam Args... Arguments to pass to the EventParam.
+     * @tparam Flags... Flags to pass to the EventParam.
+     * @param txHash The hash of the transaction to look for events.
+     * @param func The function to look for.
+     * @param anonymous (optional) Whether the event is anonymous or not.
+     */
+    template <typename TContract, typename... Args, bool... Flags>
+    std::vector<Event> getEventsEmittedByTx(const Hash& txHash,
+                                           void(TContract::*func)(const EventParam<Args, Flags>&...),
+                                           const std::tuple<EventParam<Args, Flags>...>& args,
+                                           bool anonymous = false) {
+      /// Get all the events emitted by the transaction.
+      auto eventSignature = ABI::EventEncoder::encodeSignature<Args...>(ContractReflectionInterface::getFunctionName(func));
+      std::vector<Hash> topicsToFilter;
+      if (!anonymous) {
+        topicsToFilter.push_back(eventSignature);
+      }
+      std::apply([&](const auto&... param) {
+        (..., (param.isIndexed ? topicsToFilter.push_back(ABI::EventEncoder::encodeTopicSignature(param.value)) : void()));
+      }, args);
+
+      /// Make topics.size() == 4 if its more than that.
+      if (topicsToFilter.size() > 4) {
+        topicsToFilter.resize(4);
+      }
+
+      std::vector<Event> filteredEvents;
+      auto allEvents =  this->getEvents(txHash);
+      /// Filter the events by the topics
+      for (const auto& event : allEvents) {
+        if (topicsToFilter.size() == 0) {
+          filteredEvents.push_back(event);
+        } else {
+          if (event.getTopics().size() < topicsToFilter.size()) {
+            continue;
+          }
+          bool match = true;
+          for (uint64_t i = 0; i < topicsToFilter.size(); ++i) {
+            if (topicsToFilter[i] != event.getTopics()[i]) {
+              match = false;
+              break;
+            }
+          }
+          if (match) {
+            filteredEvents.push_back(event);
+          }
+        }
+      }
+      return filteredEvents;
+    }
+
+    /// Chain owner account getter
+    const TestAccount& getChainOwnerAccount() const { return this->chainOwnerAccount_; };
+
+    /// Options getter
+    const std::unique_ptr<Options>& getOptions() const { return this->options_; };
+
+    /// DB getter
+    const std::unique_ptr<DB>& getDB() const { return this->db_; };
+
+    /// Storage getter
+    const std::unique_ptr<Storage>& getStorage() const { return this->storage_; };
+
+    /// rdPoS getter
+    const std::unique_ptr<rdPoS>& getrdPoS() const { return this->rdpos_; };
+
+    /// State getter
+    const std::unique_ptr<State>& getState() const { return this->state_; };
+
+    /// P2P getter
+    const std::unique_ptr<P2P::ManagerNormal>& getP2P() const { return this->p2p_; };
+
+    /// HTTP getter
+    const std::unique_ptr<HTTPServer>& getHTTP() const { return this->http_; };
+
+    /// Get the native balance of a given address.
+    const uint256_t getNativeBalance(const Address& address) const {
+      return this->state_->getNativeBalance(address);
+    }
+
+    /// Get the nonce of a given address
+    const uint64_t getNativeNonce(const Address& address) const {
+      return this->state_->getNativeNonce(address);
+    }
+
+    /**
+     * Initialize the services.
+     * Starts P2P and HTTP servers.
+     */
+    void initializeServices() { this->p2p_->start(); this->http_->start(); }
+
+    /**
+     * Stop the services.
+     * Stops P2P and HTTP servers.
+     */
+    void stopServices() { this->http_->stop(); this->p2p_->stop(); }
+};
+
+
+
+
+
+
+
+#endif // SDKTESTSUITE_H

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -16,6 +16,7 @@ See the LICENSE.txt file in the project root for more information.
 #include "../src/utils/options.h"
 #include "../src/utils/db.h"
 #include "../src/core/blockchain.h"
+#include "../src/utils/utils.h"
 
 /// Wrapper struct for accounts used within the SDKTestSuite.
 struct TestAccount {
@@ -803,7 +804,7 @@ class SDKTestSuite {
       // Specialization for member function pointers
       template <typename TContract, typename... Args, bool... Flags>
       struct FunctionTraits<void(TContract::*)(const EventParam<Args, Flags>&...)> {
-          using TupleType = typename ABI::Decoder::makeTupleType<EventParam<Args, Flags>...>::type;
+          using TupleType = typename Utils::makeTupleType<EventParam<Args, Flags>...>::type;
       };
     template <typename TContract, typename... Args, bool... Flags>
     auto getEventsEmittedByTxTup(const Hash& txHash,
@@ -840,7 +841,7 @@ class SDKTestSuite {
         std::vector<TupleType> tuples;
         if constexpr (!std::is_same_v<TupleType, std::tuple<>>) {
             for (const auto& event : filteredEvents) {
-                auto tuple = ABI::Decoder::decodeDataAsTuple<TupleType>(event.getData());
+                auto tuple = ABI::Decoder::decodeDataAsTuple<TupleType>::decode(event.getData());
                 tuples.push_back(tuple);
             }
         } else {

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -798,15 +798,13 @@ class SDKTestSuite {
 
     // Forward declaration for the extractor
       template <typename TFunc>
-      struct FunctionTraits;
+      struct FunctionTraits;  // Forward declaration
 
       // Specialization for member function pointers
       template <typename TContract, typename... Args, bool... Flags>
-      struct FunctionTraits<void(TContract::*)(const EventParam<Args, Flags>&...)>
-      {
+      struct FunctionTraits<void(TContract::*)(const EventParam<Args, Flags>&...)> {
           using TupleType = typename ABI::Decoder::makeTupleType<EventParam<Args, Flags>...>::type;
       };
-
     template <typename TContract, typename... Args, bool... Flags>
     auto getEventsEmittedByTxTup(const Hash& txHash,
                                 void(TContract::*func)(const EventParam<Args, Flags>&...),


### PR DESCRIPTION
## SDK Test Suite Implementation

This pull request introduces a new class within our tests: SDKTestSuite. This class seamlessly manages blockchain components (DB, State, P2P, rdPoS, State, Options) and offers a straightforward approach for performing transactions, creating contracts, and calling contract functions/events. Below is an example that demonstrates deploying an ERC20 contract and executing the transfer function, showcasing a significant ease of use compared to our previous environment.

```cpp
Address destinationOfTransfer = Address(Utils::randBytes(20));
SDKTestSuite sdkTestSuite("testSuiteDeployAndCall");
Address newContract = sdkTestSuite.deployContract<ERC20>(std::string("ERC20"), std::string("ERC20"), uint8_t(18), uint256_t("1000000000000000000"));
auto balance = sdkTestSuite.callViewFunction(newContract, &ERC20::balanceOf, sdkTestSuite.getChainOwnerAccount().address)
```
## Implementation Details:

SDKTestSuite has a single constructor, declared as follows:

```cpp
SDKTestSuite(const std::string& sdkPath,
const std::vector<TestAccount>& accounts = {},
const std::unique_ptr<Options>& options = nullptr) { /* implementation */ }
```

For most cases, using SDKTestSuite("folderPath") suffices. However, it is possible to supply a list of TestAccount and Options to initialize the blockchain, where accounts in the list will receive 1000000000000000000000 (wei) in native tokens. A newly constructed TestSuite will always have a clear DB/chain.

The TestAccount struct is defined as:

```cpp
struct TestAccount {
  const PrivKey privKey;
  const Address address;
  TestAccount() = default;
  TestAccount(const PrivKey& privKey_) : privKey(privKey_), address(Secp256k1::toAddress(Secp256k1::toPub(privKey))) {}
  static TestAccount newRandomAccount() {
    return TestAccount(Utils::randBytes(32));
  } 
  explicit operator bool() const { return bool(this->privKey); }
};
```

SDKTestSuite includes a default TestAccount, named chainOwnerAccount_, which is equivalent to the chain owner for testnet defaults (0x00dead00665771855a34155f5e7405489df2c3c6). This account is used for all functions requiring a transaction signature, unless another TestAccount is specified in the function argument.

SDKTestSuite::advanceChain() is the primary function for progressing the chain. It generates a new valid block (adhering to rdPoS rules), validates it, and adds it to the blockchain. If an automatically generated block is invalid, it will throw an exception; this is unlikely but serves as a safety measure.

Template function declarations for contract interactions are as follows:

```cpp
/**
 * Create a transaction to deploy a new contract and advance the chain with it.
 * Always use the chain owner account to deploy contracts.s
 * @tparam TContract Contract type to deploy.
 * @tparam Args... Arguments to pass to the contract constructor.
 * @return Address of the deployed contract.
 */
template <typename TContract, typename ...Args>
const Address deployContract(Args&&... args);

/**
 * Create a transaction to call a contract function and advance the chain with it.
 * Specialization for function with args
 * We are not able to set default values like in the other specialization because of the variadic template.
 * Therefore we need functions with no value/testAccount/timestamp parameters.
 * @tparam R Return type of the function.
 * @tparam TContract Contract type to call.
 * @tparam Args... Arguments to pass to the function.
 * @param contractAddress Address of the contract to call.
 * @param value Value to send with the transaction.
 * @param testAccount Account to send the transaction from.
 * @param timestamp Timestamp to use for the transaction in microseconds.
 * @param func Function to call.
 * @param args Arguments to pass to the function.
 */
template <typename R, typename TContract, typename ...Args>
const Hash callFunction(const Address& contractAddress,
                        const uint256_t& value,
                        const TestAccount& testAccount,
                        const uint64_t& timestamp,
                        R(TContract::*func)(const Args&...),
                        const Args&... args)
                        
/**
 * Call a contract view function with args and return the result.
 * @tparam R Return type of the function.
 * @tparam TContract Contract type to call.
 * @tparam Args... Arguments to pass to the function.
 * @param contractAddress Address of the contract to call.
 * @param func Function to call.
 * @param args Arguments to pass to the function.
 * @return The result of the function call. (R)
 */
template <typename R, typename TContract, typename ...Args>
const R callViewFunction(const Address& contractAddress,
                         R(TContract::*func)(const Args&...) const,
                         const Args&... args)
```

The usage can be exemplified as follows:

```cpp
sdkTestSuite.deployContract<ERC20>(std::string("ERC20"), std::string("ERC20"), uint8_t(18), uint256_t("1000000000000000000"));
sdkTestSuite.callFunction(newContract, &ERC20::transfer, destinationOfTransfer, uint256_t("10000000000000000"));
sdkTestSuite.callViewFunction(newContract, &ERC20::balanceOf, destinationOfTransfer);
```

Please refer to the implementation for a comprehensive understanding of all overloaded types and function implementations. For instance, callFunction has 9 different implementations to cover scenarios where the value, testAccount, and timestamp arguments are omitted, defaulting them to 0, the chain owner TestAccount, and std::chrono::high_resolution_clock::now(), respectively.

To retrieve specific events emitted by a transaction, developers should use the following function:

```cpp
/**
* Retrieve specific events emitted by a confirmed transaction.
* @tparam TContract Contract type.
* @tparam Args... Arguments for the EventParam.
* @tparam Flags... Flags for the EventParam.
* @param txHash Transaction hash to search for events.
* @param func Function to look for.
* @param anonymous (optional) Specify if the event is anonymous.
  */
  template <typename TContract, typename... Args, bool... Flags>
  std::vector<Event> getEventsEmittedByTx(const Hash& txHash,
  void(TContract::*func)(const EventParam<Args, Flags>&...),
  const std::tuple<EventParam<Args, Flags>...>& args,
  bool anonymous = false)
```

This can be invoked as follows:

```cpp
auto events = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged);
auto filteredEvents = sdkTestSuite.getEventsEmittedByTx(changeNameAndValueTx, &SimpleContract::nameChanged, std::make_tuple(EventParam<std::string, true>("Hello World 2!")));
```

For a detailed understanding, please consult the implementation for all declarations.

## Points for Discussion:

- **Explicit Type Requirements:** As seen in the examples, functions like deployContract and callFunction require explicit type declarations, backed by a static_assert that compares the caller-provided types with the function pointer. Is there a possibility to refine the static_assert to accommodate implicitly convertible types?
- **Event Topic Syntax:** The current syntax used for specifying event topics appears to be awkward. Are there ways to streamline this?
- **Function Pointer in Template Parameters:** Can we avoid using the function pointer on function arguments and instead incorporate it into the template parameters of the functions?

## TODO:

- Update all existing tests that depend on manual setup to utilize SDKTestSuite.
- Develop a getEventsEmittedByAddress feature to identify events emitted by a specific contract.
- Alter getEvents related functions, like getEventsEmittedByTx to return a std::tuple<Args...> where Args... represents the non-indexed arguments of the Event. This change aims to follow a format similar to:

```cpp
/**
* Proposed template to return a tuple of event arguments.
  */
  template <typename TContract, typename... Args, bool... Flags>
  std::tuple<Args...> getEventsEmittedByTx(const Hash& txHash,
  void(TContract::*func)(const EventParam<Args, Flags>&...),
  bool anonymous = false)
  {
    /// How we can derive the tuple from the function pointer?
    /// Remember that we need to ignore the indexed arguments/not return them.
  }
```

- Enable the operation of multiple instances of SDKTestSuite to simulate an authentic network environment.
