### PR TITLE
Internal refactor of P2P::Session vs. P2P::ManagerXXX classes

### DIFF
--- a/src/net/p2p/client.cpp
+++ b/src/net/p2p/client.cpp
@@ -10,7 +10,7 @@ See the LICENSE.txt file in the project root for more information.
 namespace P2P {
   void ClientFactory::createClientSession(const boost::asio::ip::address &address, const unsigned short &port) {
     tcp::socket socket(io_context_);
-    auto session = std::make_shared<Session>(std::move(socket), ConnectionType::OUTBOUND, manager_, this->threadPool_, address, port);
+    auto session = std::make_shared<Session>(std::move(socket), ConnectionType::OUTBOUND, manager_, address, port);
     session->run();
   }
 

--- a/src/net/p2p/client.cpp
+++ b/src/net/p2p/client.cpp
@@ -14,7 +14,6 @@ namespace P2P {
     session->run();
   }
 
-
   bool ClientFactory::run() {
     Logger::logToDebug(LogType::INFO, Log::P2PClientFactory, __func__,
                       "Starting P2P Client Factory "

--- a/src/net/p2p/client.h
+++ b/src/net/p2p/client.h
@@ -43,9 +43,6 @@ namespace P2P {
       /// Reference to the manager.
       ManagerBase& manager_;
 
-      /// Reference to the thread pool.
-      BS::thread_pool_light& threadPool_;
-
       /// Internal function for creating a new client session.
       void createClientSession(const boost::asio::ip::address &address, const unsigned short &port);
 
@@ -55,14 +52,12 @@ namespace P2P {
       * Constructor for the ClientFactory.
       * @param manager Reference to the manager.
       * @param threadCount Number of threads to use.
-      * @param threadPool Reference to the thread pool.
       */
-      ClientFactory(ManagerBase& manager, const uint8_t &threadCount, BS::thread_pool_light& threadPool) :
+      ClientFactory(ManagerBase& manager, const uint8_t &threadCount) :
         work_guard_(boost::asio::make_work_guard(io_context_)),
         connectorStrand_(io_context_.get_executor()),
         threadCount_(threadCount),
-        manager_(manager),
-        threadPool_(threadPool) {}
+        manager_(manager) {}
 
       /// Start the Factory.
       bool start();

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -99,18 +99,18 @@ namespace P2P {
   }
 
   void ManagerBase::start() {
-    std::scoped_lock lock(stateMutex_);
-    if (started_) return;
-    started_ = true;
-    threadPool_ = std::make_unique<BS::thread_pool_light>(std::thread::hardware_concurrency() * 4);
+    std::scoped_lock lock(this->stateMutex_);
+    if (this->started_) return;
+    this->started_ = true;
+    this->threadPool_ = std::make_unique<BS::thread_pool_light>(std::thread::hardware_concurrency() * 4);
     this->server_.start();
     this->clientfactory_.start();
   }
 
   void ManagerBase::stop() {
-    std::scoped_lock lock(stateMutex_);
-    if (! started_) return;
-    started_ = false;
+    std::scoped_lock lock(this->stateMutex_);
+    if (! this->started_) return;
+    this->started_ = false;
     {
       std::unique_lock lock(this->sessionsMutex_);
       for (auto it = sessions_.begin(); it != sessions_.end();) {
@@ -121,13 +121,13 @@ namespace P2P {
     }
     this->server_.stop();
     this->clientfactory_.stop();
-    threadPool_.reset();
+    this->threadPool_.reset();
   }
 
   void ManagerBase::asyncHandleMessage(const NodeID &nodeId, const std::shared_ptr<const Message> message) {
-    std::shared_lock lock(stateMutex_);
-    if (threadPool_) {
-      threadPool_->push_task(&ManagerBase::handleMessage, this, nodeId, message);
+    std::shared_lock lock(this->stateMutex_);
+    if (this->threadPool_) {
+      this->threadPool_->push_task(&ManagerBase::handleMessage, this, nodeId, message);
     }
   }
 

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -59,17 +59,6 @@ namespace P2P {
     return true;
   }
 
-  std::weak_ptr<Session> ManagerBase::getWeakPtrToSession(const NodeID &nodeId) {
-    if (! this->closed_) {
-      std::shared_lock<std::shared_mutex> lockSession(this->sessionsMutex_);
-      auto it = sessions_.find(nodeId);
-      if (it != sessions_.end()) {
-        return std::weak_ptr<Session>(it->second);
-      }
-    }
-    return std::weak_ptr<Session>();
-  }
-
   std::shared_ptr<Request> ManagerBase::sendRequestTo(const NodeID &nodeId, const std::shared_ptr<const Message>& message) {
     if (this->closed_) return nullptr;
     std::shared_lock<std::shared_mutex> lockSession(this->sessionsMutex_); // ManagerBase::sendRequestTo doesn't change sessions_ map.

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -96,7 +96,7 @@ namespace P2P {
   // ManagerBase::answerSession doesn't change sessions_ map, but we still need to
   // be sure that the session io_context doesn't get deleted while we are using it.
   void ManagerBase::answerSession(const NodeID &nodeId, const std::shared_ptr<const Message>& message) {
-    std::shared_lock<std::shared_mutex> lockSession(this->sessionsMutex_);
+    std::shared_lock lockSession(this->sessionsMutex_);
     if (this->closed_) return;
     auto it = sessions_.find(nodeId);
     if (it == sessions_.end()) {

--- a/src/net/p2p/managerbase.h
+++ b/src/net/p2p/managerbase.h
@@ -75,9 +75,6 @@ namespace P2P {
       /// Internal disconnect function for sessions.
       bool disconnectSessionInternal(const NodeID& session);
 
-      /// Get a weak_ptr<Session> for a nodeId (nullptr if none found)
-      std::weak_ptr<Session> getWeakPtrToSession(const NodeID &nodeId);
-
       /**
        * Send a Request to a given node.
        * @param nodeId The ID of the node to send the message to.

--- a/src/net/p2p/managerbase.h
+++ b/src/net/p2p/managerbase.h
@@ -75,6 +75,9 @@ namespace P2P {
       /// Internal disconnect function for sessions.
       bool disconnectSessionInternal(const NodeID& session);
 
+      /// Get a weak_ptr<Session> for a nodeId (nullptr if none found)
+      std::weak_ptr<Session> getWeakPtrToSession(const NodeID &nodeId);
+
       /**
        * Send a Request to a given node.
        * @param nodeId The ID of the node to send the message to.
@@ -88,7 +91,7 @@ namespace P2P {
        * @param session The session to answer to.
        * @param message The message to answer.
        */
-      void answerSession(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void answerSession(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       // TODO: There is a bug with handleRequest that throws std::system_error.
       // I believe that this is related with the std::shared_ptr<Session> getting deleted or
@@ -98,7 +101,7 @@ namespace P2P {
        * @param session The session that sent the message.
        * @param message The message to handle.
        */
-      virtual void handleRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) {
+      virtual void handleRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message) {
         // Do nothing by default, child classes are meant to override this
       }
 
@@ -107,7 +110,7 @@ namespace P2P {
        * @param session The session that sent the message.
        * @param message The message to handle.
        */
-      virtual void handleAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) {
+      virtual void handleAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message) {
         // Do nothing by default, child classes are meant to override this
       }
 
@@ -209,7 +212,7 @@ namespace P2P {
        * @param session The session to send an answer to.
        * @param message The message to handle.
        */
-      virtual void handleMessage(std::weak_ptr<Session> session, const std::shared_ptr<const Message> message) {
+      virtual void handleMessage(const NodeID &nodeId, const std::shared_ptr<const Message> message) {
         // Do nothing by default, child classes are meant to override this
       }
 

--- a/src/net/p2p/managerdiscovery.cpp
+++ b/src/net/p2p/managerdiscovery.cpp
@@ -20,18 +20,10 @@ namespace P2P {
         handleAnswer(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid message type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-            std::to_string(sessionPtr->hostNodeId().second) + " closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid message type from unknown session, the session ran away."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid message type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           " closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -47,18 +39,10 @@ namespace P2P {
         handleRequestNodesRequest(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Request Command Type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-            std::to_string(sessionPtr->hostNodeId().second) + ", closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Request Command Type from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid Request Command Type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           ", closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -76,18 +60,10 @@ namespace P2P {
         handleRequestNodesAnswer(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Answer Command Type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-            std::to_string(sessionPtr->hostNodeId().second) + ", closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Answer Command Type from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid Answer Command Type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           ", closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -95,19 +71,11 @@ namespace P2P {
   void ManagerDiscovery::handlePingRequest(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::ping(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid ping request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid ping request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid ping request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
@@ -116,19 +84,10 @@ namespace P2P {
   void ManagerDiscovery::handleRequestNodesRequest(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestNodes(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestNodes request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestNodes request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid requestNodes request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
 
@@ -151,18 +110,10 @@ namespace P2P {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -174,18 +125,10 @@ namespace P2P {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);

--- a/src/net/p2p/managerdiscovery.cpp
+++ b/src/net/p2p/managerdiscovery.cpp
@@ -11,7 +11,7 @@ namespace P2P {
   void ManagerDiscovery::handleMessage(
     const NodeID &nodeId, const std::shared_ptr<const Message> message
   ) {
-    if (this->closed_) return;
+    if (!this->started_) return;
     switch (message->type()) {
       case Requesting:
         handleRequest(nodeId, message);

--- a/src/net/p2p/managerdiscovery.cpp
+++ b/src/net/p2p/managerdiscovery.cpp
@@ -9,17 +9,18 @@ See the LICENSE.txt file in the project root for more information.
 
 namespace P2P {
   void ManagerDiscovery::handleMessage(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message> message
+    const NodeID &nodeId, const std::shared_ptr<const Message> message
   ) {
     if (this->closed_) return;
     switch (message->type()) {
       case Requesting:
-        handleRequest(session, message);
+        handleRequest(nodeId, message);
         break;
       case Answering:
-        handleAnswer(session, message);
+        handleAnswer(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid message type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -36,16 +37,17 @@ namespace P2P {
   }
 
   void ManagerDiscovery::handleRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     switch (message->command()) {
       case Ping:
-        handlePingRequest(session, message);
+        handlePingRequest(nodeId, message);
         break;
       case RequestNodes:
-        handleRequestNodesRequest(session, message);
+        handleRequestNodesRequest(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid Request Command Type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -62,18 +64,19 @@ namespace P2P {
   }
 
   void ManagerDiscovery::handleAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     switch (message->command()) {
       case Ping:
-        handlePingAnswer(session, message);
+        handlePingAnswer(nodeId, message);
         break;
       case Info:
         break;
       case RequestNodes:
-        handleRequestNodesAnswer(session, message);
+        handleRequestNodesAnswer(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid Answer Command Type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -90,8 +93,9 @@ namespace P2P {
   }
 
   void ManagerDiscovery::handlePingRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::ping(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -106,12 +110,13 @@ namespace P2P {
       }
       return;
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
   }
 
   void ManagerDiscovery::handleRequestNodesRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestNodes(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -137,15 +142,16 @@ namespace P2P {
         }
       );
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::requestNodes(*message, nodes)));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestNodes(*message, nodes)));
   }
 
   void ManagerDiscovery::handlePingAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -163,11 +169,12 @@ namespace P2P {
   }
 
   void ManagerDiscovery::handleRequestNodesAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +

--- a/src/net/p2p/managerdiscovery.h
+++ b/src/net/p2p/managerdiscovery.h
@@ -22,14 +22,14 @@ namespace P2P {
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) override;
+      void handleRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message) override;
 
       /**
        * Handle an answer from a server.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) override;
+      void handleAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message) override;
 
     private:
       /**
@@ -37,28 +37,28 @@ namespace P2P {
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handlePingRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handlePingRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestNodes` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleRequestNodesRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleRequestNodesRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `Ping` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handlePingAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handlePingAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestNodes` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleRequestNodesAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleRequestNodesAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
     public:
       /**
@@ -78,7 +78,7 @@ namespace P2P {
        * @param session The session that sent the message.
        * @param message The message to handle.
        */
-      void handleMessage(std::weak_ptr<Session> session, const std::shared_ptr<const Message> message) override;
+      void handleMessage(const NodeID &nodeId, const std::shared_ptr<const Message> message) override;
   };
 };
 

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -36,20 +36,21 @@ namespace P2P{
   }
 
   void ManagerNormal::handleMessage(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message> message
+    const NodeID &nodeId, const std::shared_ptr<const Message> message
   ) {
     if (this->closed_) return;
     switch (message->type()) {
       case Requesting:
-        handleRequest(session, message);
+        handleRequest(nodeId, message);
         break;
       case Answering:
-        handleAnswer(session, message);
+        handleAnswer(nodeId, message);
         break;
       case Broadcasting:
-        handleBroadcast(session, message);
+        handleBroadcast(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid message type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -67,25 +68,26 @@ namespace P2P{
   }
 
   void ManagerNormal::handleRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     switch (message->command()) {
       case Ping:
-        handlePingRequest(session, message);
+        handlePingRequest(nodeId, message);
         break;
       case Info:
-        handleInfoRequest(session, message);
+        handleInfoRequest(nodeId, message);
         break;
       case RequestNodes:
-        handleRequestNodesRequest(session, message);
+        handleRequestNodesRequest(nodeId, message);
         break;
       case RequestValidatorTxs:
-        handleTxValidatorRequest(session, message);
+        handleTxValidatorRequest(nodeId, message);
         break;
       case RequestTxs:
-        handleTxRequest(session, message);
+        handleTxRequest(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid Request Command Type: " + std::to_string(message->command())
@@ -104,25 +106,26 @@ namespace P2P{
   }
 
   void ManagerNormal::handleAnswer(
-      std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+      const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     switch (message->command()) {
       case Ping:
-        handlePingAnswer(session, message);
+        handlePingAnswer(nodeId, message);
         break;
       case Info:
-        handleInfoAnswer(session, message);
+        handleInfoAnswer(nodeId, message);
         break;
       case RequestNodes:
-        handleRequestNodesAnswer(session, message);
+        handleRequestNodesAnswer(nodeId, message);
         break;
       case RequestValidatorTxs:
-        handleTxValidatorAnswer(session, message);
+        handleTxValidatorAnswer(nodeId, message);
         break;
       case RequestTxs:
-        handleTxAnswer(session, message);
+        handleTxAnswer(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid Answer Command Type: " + std::to_string(message->command())
@@ -141,7 +144,7 @@ namespace P2P{
   }
 
   void ManagerNormal::handleBroadcast(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (this->closed_) return;
     {
@@ -158,15 +161,16 @@ namespace P2P{
     }
     switch (message->command()) {
       case BroadcastValidatorTx:
-        handleTxValidatorBroadcast(session, message);
+        handleTxValidatorBroadcast(nodeId, message);
         break;
       case BroadcastTx:
-        handleTxBroadcast(session, message);
+        handleTxBroadcast(nodeId, message);
         break;
       case BroadcastBlock:
-        handleBlockBroadcast(session, message);
+        handleBlockBroadcast(nodeId, message);
         break;
       default:
+        auto session = getWeakPtrToSession(nodeId);
         if (auto sessionPtr = session.lock()) {
           Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
             "Invalid Broadcast Command Type: " + std::to_string(message->command())
@@ -185,8 +189,9 @@ namespace P2P{
   }
 
   void ManagerNormal::handlePingRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::ping(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -201,21 +206,22 @@ namespace P2P{
       }
       return;
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
   }
 
   void ManagerNormal::handleInfoRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     RequestDecoder::info(*message);
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::info(
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::info(
       *message, this->storage_.latest(), this->options_
     )));
   }
 
   void ManagerNormal::handleRequestNodesRequest(
-      std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+      const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestNodes(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -241,12 +247,13 @@ namespace P2P{
                      }
       );
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::requestNodes(*message, nodes)));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestNodes(*message, nodes)));
   }
 
   void ManagerNormal::handleTxValidatorRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestValidatorTxs(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -261,12 +268,13 @@ namespace P2P{
       }
       return;
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::requestValidatorTxs(*message, this->rdpos_.getMempool())));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestValidatorTxs(*message, this->rdpos_.getMempool())));
   }
 
   void ManagerNormal::handleTxRequest(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
+    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestTxs(*message)) {
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
@@ -281,15 +289,16 @@ namespace P2P{
       }
       return;
     }
-    this->answerSession(session, std::make_shared<const Message>(AnswerEncoder::requestTxs(*message, this->state_.getMempool())));
+    this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestTxs(*message, this->state_.getMempool())));
   }
 
   void ManagerNormal::handlePingAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before doing anything else to avoid waiting for other locks.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -307,11 +316,12 @@ namespace P2P{
   }
 
   void ManagerNormal::handleInfoAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -329,11 +339,12 @@ namespace P2P{
   }
 
   void ManagerNormal::handleRequestNodesAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -351,11 +362,12 @@ namespace P2P{
   }
 
   void ManagerNormal::handleTxValidatorAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -373,11 +385,12 @@ namespace P2P{
   }
 
   void ManagerNormal::handleTxAnswer(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -395,12 +408,13 @@ namespace P2P{
   }
 
   void ManagerNormal::handleTxValidatorBroadcast(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     try {
       auto tx = BroadcastDecoder::broadcastValidatorTx(*message, this->options_.getChainID());
       if (this->state_.addValidatorTx(tx)) this->broadcastMessage(message);
     } catch (std::exception &e) {
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Invalid txValidatorBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -416,12 +430,13 @@ namespace P2P{
   }
 
   void ManagerNormal::handleTxBroadcast(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     try {
       auto tx = BroadcastDecoder::broadcastTx(*message, this->options_.getChainID());
       if (!this->state_.addTx(std::move(tx))) this->broadcastMessage(message);
     } catch (std::exception &e) {
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Invalid txBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +
@@ -437,7 +452,7 @@ namespace P2P{
   }
 
   void ManagerNormal::handleBlockBroadcast(
-    std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message
+    const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     // We require a lock here because validateNextBlock **throws** if the block is invalid.
     // The reason for locking because for that a processNextBlock race condition can occur,
@@ -456,6 +471,7 @@ namespace P2P{
         rebroadcast = true;
       }
     } catch (std::exception &e) {
+      auto session = getWeakPtrToSession(nodeId);
       if (auto sessionPtr = session.lock()) {
         Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
           "Invalid blockBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -12,7 +12,7 @@ See the LICENSE.txt file in the project root for more information.
 
 namespace P2P{
   void ManagerNormal::broadcastMessage(const std::shared_ptr<const Message> message) {
-    if (this->closed_) return;
+    if (!this->started_) return;
     {
       std::unique_lock broadcastLock(this->broadcastMutex_);
       if (broadcastedMessages_[message->id().toUint64()] > 0) {
@@ -38,7 +38,7 @@ namespace P2P{
   void ManagerNormal::handleMessage(
     const NodeID &nodeId, const std::shared_ptr<const Message> message
   ) {
-    if (this->closed_) return;
+    if (!this->started_) return;
     switch (message->type()) {
       case Requesting:
         handleRequest(nodeId, message);
@@ -118,7 +118,7 @@ namespace P2P{
   void ManagerNormal::handleBroadcast(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    if (this->closed_) return;
+    if (!this->started_) return;
     {
       std::shared_lock broadcastLock(this->broadcastMutex_);
       auto it = broadcastedMessages_.find(message->id().toUint64());

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -50,19 +50,9 @@ namespace P2P{
         handleBroadcast(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid message type from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-            std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-          );
-
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid message type from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid message type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " , closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -87,20 +77,11 @@ namespace P2P{
         handleTxRequest(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Request Command Type: " + std::to_string(message->command())
-            + " from: " + sessionPtr->hostNodeId().first.to_string() + ":" +
-              std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Request Command Type: " + std::to_string(message->command())
-            + " from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid Request Command Type: " + std::to_string(message->command()) +
+                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           ", closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -125,20 +106,11 @@ namespace P2P{
         handleTxAnswer(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Answer Command Type: " + std::to_string(message->command())
-            + " from: " + sessionPtr->hostNodeId().first.to_string() + ":" +
-              std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Answer Command Type: " + std::to_string(message->command())
-            + " from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid Answer Command Type: " + std::to_string(message->command()) +
+                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           " , closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -170,20 +142,11 @@ namespace P2P{
         handleBlockBroadcast(nodeId, message);
         break;
       default:
-        auto session = getWeakPtrToSession(nodeId);
-        if (auto sessionPtr = session.lock()) {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Broadcast Command Type: " + std::to_string(message->command())
-            + " from: " + sessionPtr->hostNodeId().first.to_string() + ":" +
-              std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-          );
-          this->disconnectSession(sessionPtr->hostNodeId());
-        } else {
-          Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-            "Invalid Broadcast Command Type: " + std::to_string(message->command())
-            + " from unknown session, closing session."
-          );
-        }
+        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                           "Invalid Broadcast Command Type: " + std::to_string(message->command()) +
+                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                           " , closing session.");
+        this->disconnectSession(nodeId);
         break;
     }
   }
@@ -191,19 +154,11 @@ namespace P2P{
   void ManagerNormal::handlePingRequest(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::ping(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid ping request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid ping request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid ping request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::ping(*message)));
@@ -221,19 +176,11 @@ namespace P2P{
   void ManagerNormal::handleRequestNodesRequest(
       const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestNodes(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestNodes request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestNodes request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid requestNodes request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
 
@@ -253,19 +200,11 @@ namespace P2P{
   void ManagerNormal::handleTxValidatorRequest(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestValidatorTxs(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestValidatorTxs request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestValidatorTxs request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid requestValidatorTxs request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestValidatorTxs(*message, this->rdpos_.getMempool())));
@@ -274,19 +213,11 @@ namespace P2P{
   void ManagerNormal::handleTxRequest(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    auto session = getWeakPtrToSession(nodeId);
     if (!RequestDecoder::requestTxs(*message)) {
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestTxs request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid requestTxs request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid requestTxs request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     this->answerSession(nodeId, std::make_shared<const Message>(AnswerEncoder::requestTxs(*message, this->state_.getMempool())));
@@ -298,18 +229,10 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before doing anything else to avoid waiting for other locks.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -321,18 +244,10 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -344,18 +259,10 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -367,18 +274,10 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -390,18 +289,10 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Answer to invalid request from unknown session, closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Answer to invalid request from " + nodeId.first.to_string() + ":" +
+                         std::to_string(nodeId.second) + " , closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     requests_[message->id()]->setAnswer(message);
@@ -414,18 +305,10 @@ namespace P2P{
       auto tx = BroadcastDecoder::broadcastValidatorTx(*message, this->options_.getChainID());
       if (this->state_.addValidatorTx(tx)) this->broadcastMessage(message);
     } catch (std::exception &e) {
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid txValidatorBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , error: " + e.what() + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          std::string("Invalid txValidatorBroadcast from unknown session, error: ") + e.what() + " closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid txValidatorBroadcast from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , error: " + e.what() + " closing session.");
+      this->disconnectSession(nodeId);
     }
   }
 
@@ -436,18 +319,10 @@ namespace P2P{
       auto tx = BroadcastDecoder::broadcastTx(*message, this->options_.getChainID());
       if (!this->state_.addTx(std::move(tx))) this->broadcastMessage(message);
     } catch (std::exception &e) {
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid txBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , error: " + e.what() + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          std::string("Invalid txBroadcast from unknown session, error: ") + e.what() + " closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid txBroadcast from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , error: " + e.what() + " closing session.");
+      this->disconnectSession(nodeId);
     }
   }
 
@@ -471,18 +346,10 @@ namespace P2P{
         rebroadcast = true;
       }
     } catch (std::exception &e) {
-      auto session = getWeakPtrToSession(nodeId);
-      if (auto sessionPtr = session.lock()) {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          "Invalid blockBroadcast from " + sessionPtr->hostNodeId().first.to_string() + ":" +
-          std::to_string(sessionPtr->hostNodeId().second) + " , error: " + e.what() + " closing session."
-        );
-        this->disconnectSession(sessionPtr->hostNodeId());
-      } else {
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-          std::string("Invalid blockBroadcast from unknown session, error: ") + e.what() + " closing session."
-        );
-      }
+      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
+                         "Invalid blockBroadcast from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+                         " , error: " + e.what() + " closing session.");
+      this->disconnectSession(nodeId);
       return;
     }
     if (rebroadcast) this->broadcastMessage(message);

--- a/src/net/p2p/managernormal.h
+++ b/src/net/p2p/managernormal.h
@@ -24,21 +24,21 @@ namespace P2P {
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) override;
+      void handleRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message) override;
 
       /**
        * Handle an answer from a server.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message) override;
+      void handleAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message) override;
 
       /**
        * Handle a broadcast from a node.
        * @param session The session that sent the broadcast.
        * @param message The broadcast message to handle.
        */
-      void handleBroadcast(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleBroadcast(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
     private:
       /// Reference to the rdPoS object.
@@ -73,91 +73,91 @@ namespace P2P {
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handlePingRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handlePingRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `Info` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleInfoRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleInfoRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestNodes` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleRequestNodesRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleRequestNodesRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestValidatorTxs` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleTxValidatorRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxValidatorRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestTxs` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.
        */
-      void handleTxRequest(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxRequest(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `Ping` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handlePingAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handlePingAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `Info` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleInfoAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleInfoAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestNodes` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleRequestNodesAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleRequestNodesAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestValidatorTxs` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleTxValidatorAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxValidatorAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a `RequestTxs` answer.
        * @param session The session that sent the answer.
        * @param message The answer message to handle.
        */
-      void handleTxAnswer(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxAnswer(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a Validator transaction broadcast message.
        * @param session The node that sent the broadcast.
        * @param message The message that was broadcast.
        */
-      void handleTxValidatorBroadcast(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxValidatorBroadcast(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a block transaction broadcast message.
        * @param session The node that sent the broadcast.
        * @param message The message that was broadcast.
        */
-      void handleTxBroadcast(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleTxBroadcast(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
       /**
        * Handle a block broadcast message.
        * @param session The node that sent the broadcast.
        * @param message The message that was broadcast.
        */
-      void handleBlockBroadcast(std::weak_ptr<Session> session, const std::shared_ptr<const Message>& message);
+      void handleBlockBroadcast(const NodeID &nodeId, const std::shared_ptr<const Message>& message);
 
     public:
       /**
@@ -184,7 +184,7 @@ namespace P2P {
        * @param session The session that sent the message.
        * @param message The message to handle.
        */
-      void handleMessage(std::weak_ptr<Session> session, const std::shared_ptr<const Message> message) override;
+      void handleMessage(const NodeID &nodeId, const std::shared_ptr<const Message> message) override;
 
       /**
        * Request Validator transactions from a given node.

--- a/src/net/p2p/server.cpp
+++ b/src/net/p2p/server.cpp
@@ -26,7 +26,7 @@ namespace P2P {
       /// TODO: Handle error
       return;
     } else {
-      std::make_shared<Session>(std::move(socket), ConnectionType::INBOUND, this->manager_, this->threadPool_)->run();
+      std::make_shared<Session>(std::move(socket), ConnectionType::INBOUND, this->manager_)->run();
     }
     this->do_accept();
   }
@@ -59,7 +59,7 @@ namespace P2P {
       io_context_.restart();
       Logger::logToDebug(LogType::DEBUG, Log::P2PServer, __func__, "Starting listener.");
       this->listener_ = std::make_shared<ServerListener>(
-          io_context_, tcp::endpoint{this->localAddress_, this->localPort_}, this->manager_, this->threadPool_
+        io_context_, tcp::endpoint{this->localAddress_, this->localPort_}, this->manager_
       );
       this->listener_->run();
       Logger::logToDebug(LogType::DEBUG, Log::P2PServer, __func__, "Listener started.");

--- a/src/net/p2p/server.cpp
+++ b/src/net/p2p/server.cpp
@@ -6,6 +6,7 @@ See the LICENSE.txt file in the project root for more information.
 */
 
 #include "server.h"
+#include "managerbase.h"
 
 namespace P2P {
   void ServerListener::do_accept() {

--- a/src/net/p2p/server.h
+++ b/src/net/p2p/server.h
@@ -28,24 +28,19 @@ namespace P2P {
       void on_accept(boost::system::error_code ec, net::ip::tcp::socket socket);
       /// Pointer back to the Manager object.
       ManagerBase& manager_;
-      /// Reference to the thread pool.
-      BS::thread_pool_light& threadPool_;
     public:
       /**
        * Constructor for the ServerListener.
        * @param io_context Reference to the server io_context.
        * @param endpoint The endpoint to listen on.
        * @param manager Reference to the manager.
-       * @param threadPool Reference to the thread pool.
        */
       ServerListener(net::io_context& io_context,
                      tcp::endpoint endpoint,
-                     ManagerBase& manager,
-                     BS::thread_pool_light& threadPool) :
+                     ManagerBase& manager) :
         io_context_(io_context),
         acceptor_(io_context),
-        manager_(manager),
-        threadPool_(threadPool) {
+        manager_(manager) {
          boost::system::error_code ec;
          acceptor_.open(endpoint.protocol(), ec); // Open the acceptor
          if (ec) { Logger::logToDebug(LogType::ERROR, Log::P2PServerListener, __func__, "Open Acceptor: " + ec.message()); return; }
@@ -88,9 +83,6 @@ namespace P2P {
       /// Pointer to the manager.
       ManagerBase& manager_;
 
-      /// Reference to the thread pool.
-      BS::thread_pool_light& threadPool_;
-
     public:
       /**
       * Constructor for the server.
@@ -98,18 +90,15 @@ namespace P2P {
       * @param localPort The local port.
       * @param threadCount Reference to the thread count.
       * @param manager Reference to the manager.
-      * @param threadPool Reference to the thread pool.
       */
       Server(const net::ip::address &localAddress,
              const uint16_t &localPort,
              const uint8_t& threadCount,
-             ManagerBase& manager,
-             BS::thread_pool_light& threadPool) :
+             ManagerBase& manager) :
         localAddress_(localAddress),
         localPort_(localPort),
         threadCount_(threadCount),
-        manager_(manager),
-        threadPool_(threadPool)
+        manager_(manager)
         {}
 
       /// Start the Server.

--- a/src/net/p2p/server.h
+++ b/src/net/p2p/server.h
@@ -7,6 +7,9 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "session.h"
 
+#ifndef P2P_SERVER
+#define P2P_SERVER
+
 namespace P2P {
   /**
    * ServerListener class
@@ -123,3 +126,4 @@ namespace P2P {
   };
 }
 
+#endif

--- a/src/net/p2p/session.cpp
+++ b/src/net/p2p/session.cpp
@@ -111,7 +111,7 @@ namespace P2P {
 
   void Session::on_read_message(boost::system::error_code ec, std::size_t) {
     if (ec && this->handle_error(__func__, ec)) return;
-    manager_.asyncHandleMessage(nodeId_, inboundMessage_);
+    this->manager_.asyncHandleMessage(this->nodeId_, this->inboundMessage_);
     this->inboundMessage_ = nullptr;
     this->do_read_header();
   }

--- a/src/net/p2p/session.cpp
+++ b/src/net/p2p/session.cpp
@@ -113,7 +113,7 @@ namespace P2P {
     if (ec && this->handle_error(__func__, ec)) return;
     // Make it a unique_ptr<const Message> so that we can pass it to the thread pool.
     this->threadPool_.push_task(
-      &ManagerBase::handleMessage, &this->manager_, weak_from_this(), this->inboundMessage_
+      &ManagerBase::handleMessage, &this->manager_, nodeId_, this->inboundMessage_
     );
     this->inboundMessage_ = nullptr;
     this->do_read_header();

--- a/src/net/p2p/session.cpp
+++ b/src/net/p2p/session.cpp
@@ -111,10 +111,7 @@ namespace P2P {
 
   void Session::on_read_message(boost::system::error_code ec, std::size_t) {
     if (ec && this->handle_error(__func__, ec)) return;
-    // Make it a unique_ptr<const Message> so that we can pass it to the thread pool.
-    this->threadPool_.push_task(
-      &ManagerBase::handleMessage, &this->manager_, nodeId_, this->inboundMessage_
-    );
+    manager_.asyncHandleMessage(nodeId_, inboundMessage_);
     this->inboundMessage_ = nullptr;
     this->do_read_header();
   }

--- a/src/net/p2p/session.h
+++ b/src/net/p2p/session.h
@@ -19,7 +19,6 @@ See the LICENSE.txt file in the project root for more information.
 #include <boost/asio/buffer.hpp>
 
 #include "../../utils/utils.h"
-#include "../../libs/BS_thread_pool_light.hpp"
 #include "encoding.h"
 
 using boost::asio::ip::tcp;
@@ -59,9 +58,6 @@ namespace P2P {
 
       /// Reference back to the Manager object.
       ManagerBase& manager_;
-
-      /// Reference to the thread pool.
-      BS::thread_pool_light& threadPool_;
 
       net::strand<net::any_io_executor> readStrand_; ///< Strand for read operations.
       net::strand<net::any_io_executor> writeStrand_; ///< Strand for write operations.
@@ -139,13 +135,11 @@ namespace P2P {
       /// Construct a session with the given socket. (Used by the server)
       explicit Session(tcp::socket &&socket,
                        ConnectionType connectionType,
-                       ManagerBase& manager,
-                       BS::thread_pool_light& threadPool)
+                       ManagerBase& manager)
           : socket_(std::move(socket)),
             readStrand_(socket_.get_executor()),
             writeStrand_(socket_.get_executor()),
             manager_(manager),
-            threadPool_(threadPool),
             address_(socket_.remote_endpoint().address()),
             port_(socket_.remote_endpoint().port()),
             connectionType_(connectionType)
@@ -160,7 +154,6 @@ namespace P2P {
       explicit Session(tcp::socket &&socket,
                        ConnectionType connectionType,
                        ManagerBase& manager,
-                       BS::thread_pool_light& threadPool,
                        const net::ip::address& address,
                        unsigned short port
                        )
@@ -168,7 +161,6 @@ namespace P2P {
             readStrand_(socket_.get_executor()),
             writeStrand_(socket_.get_executor()),
             manager_(manager),
-            threadPool_(threadPool),
             address_(address),
             port_(port),
             connectionType_(connectionType)

--- a/tests/core/state.cpp
+++ b/tests/core/state.cpp
@@ -465,7 +465,12 @@ namespace TState {
         }
       });
 
-      REQUIRE(discoveryFuture.wait_for(std::chrono::seconds(5)) != std::future_status::timeout);
+      // TODO: This had a 5s timeout, but this is temporarily increased to avoid random failures.
+      auto start = std::chrono::high_resolution_clock::now();
+      REQUIRE(discoveryFuture.wait_for(std::chrono::seconds(120)) != std::future_status::timeout);
+      auto end = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+      if (duration > 5000) std::cout << "WARNING ([state]): discoveryFuture elapsed time: " << duration << " ms" << std::endl;
 
       REQUIRE(p2pDiscovery.getSessionsIDs().size() == 8);
       REQUIRE(blockchainWrapper1.p2p.getSessionsIDs().size() == 1);
@@ -1500,7 +1505,12 @@ namespace TState {
             });
 
             // Sleep for blocks to be broadcasted and accepted.
-            REQUIRE(broadcastBlockFuture.wait_for(std::chrono::seconds(5)) != std::future_status::timeout);
+            // TODO: This had a 5s timeout, but this is temporarily increased to avoid random failures.
+            auto start = std::chrono::high_resolution_clock::now();
+            REQUIRE(broadcastBlockFuture.wait_for(std::chrono::seconds(120)) != std::future_status::timeout);
+            auto end = std::chrono::high_resolution_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+            if (duration > 5000) std::cout << "WARNING ([state]): broadcastBlockFuture elapsed time: " << duration << " ms" << std::endl;
 
             // Check if the block was accepted by all nodes.
             REQUIRE(blockchainWrapper1.storage.latest()->hash() == blockchainWrapper2.storage.latest()->hash());


### PR DESCRIPTION
This changes the `std::weak_ptr<Session>`  argument in `P2P::ManagerXXX` APIs to `NodeId` instead, which induces an additional lookup for the Session object from that NodeId.

I'm also including some changes to the P2P::ManagerBase start / stop.