### PR TITLE
SafeUnorderedMap fixes

### DIFF
--- a/src/contract/variables/safeunorderedmap.h
+++ b/src/contract/variables/safeunorderedmap.h
@@ -26,8 +26,8 @@ template <typename Key, typename T> class SafeUnorderedMap : public SafeBase {
     std::unordered_map<Key, T, SafeHash> map_; ///< Value.
     mutable std::unique_ptr<std::unordered_map<Key, T, SafeHash>> mapPtr_; ///< Pointer to the value.
     mutable std::unique_ptr<std::unordered_set<Key, SafeHash>> erasedKeys_; ///< Pointer to the set of erased keys in map_ (not mapPtr_).
-    mutable uint64_t size_;
-    mutable bool dirtySize_;
+    mutable uint64_t size_; ///< Cache of this container's element count (valid only if dirtySize_ == false)
+    mutable bool dirtySize_; ///< True if size_ has to be be recomputed
 
     /// Check if pointers are initialized (and initialize them if not).
     inline void check() const override {

--- a/tests/contract/variables/safeunorderedmap.cpp
+++ b/tests/contract/variables/safeunorderedmap.cpp
@@ -9,16 +9,13 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/contract/variables/safeunorderedmap.h"
 #include <iostream>
 
-
-
 namespace TSafeUnorderedMap {
   TEST_CASE("SafeUnorderedMap Class", "[contract][variables][safeunorderedmap]") {
     SECTION("SafeUnorderedMap Constructor") {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
@@ -127,8 +124,7 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
@@ -146,8 +142,7 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
@@ -162,8 +157,7 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
@@ -176,26 +170,53 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
       safeUnorderedMap.commit();
-      SafeUnorderedMap safeUnorderedMapCopy = safeUnorderedMap;
+      SafeUnorderedMap<Address, uint256_t> safeUnorderedMapCopy;
+      safeUnorderedMapCopy = safeUnorderedMap;
       safeUnorderedMapCopy.commit();
       REQUIRE(safeUnorderedMap.size() == 1);
       REQUIRE(safeUnorderedMap[randomAddress] == uint256_t("19283815712031512"));
       REQUIRE(safeUnorderedMapCopy.size() == 1);
       REQUIRE(safeUnorderedMapCopy[randomAddress] == uint256_t("19283815712031512"));
+      auto randomAddress2 = Address(Utils::randBytes(20));
+      REQUIRE(randomAddress != randomAddress2);
+      safeUnorderedMap[randomAddress2] = uint256_t("11111111111111111");
+      REQUIRE(safeUnorderedMap.size() == 2);
+      auto it = safeUnorderedMap.find(randomAddress);
+      safeUnorderedMap.erase(it);
+      REQUIRE(safeUnorderedMap.size() == 1);
+      safeUnorderedMapCopy = safeUnorderedMap;
+      REQUIRE(safeUnorderedMapCopy.size() == 1);
+      it = safeUnorderedMapCopy.find(randomAddress);
+      REQUIRE(it == safeUnorderedMapCopy.end());
+      it = safeUnorderedMapCopy.find(randomAddress2);
+      REQUIRE(it != safeUnorderedMapCopy.end());
+      REQUIRE(it->second == uint256_t("11111111111111111"));
+      safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
+      REQUIRE(safeUnorderedMap.size() == 2);
+    }
+
+    SECTION("SafeUnorderedMap erase-insert-commit regression") {
+      SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
+      auto randomAddress = Address(Utils::randBytes(20));
+      safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
+      safeUnorderedMap.commit();
+      auto it = safeUnorderedMap.find(randomAddress);
+      safeUnorderedMap.erase(it);
+      safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
+      safeUnorderedMap.commit();
+      REQUIRE(safeUnorderedMap[randomAddress] == uint256_t("19283815712031512"));
     }
 
     SECTION("SafeUnorderedMap count") {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));
@@ -210,8 +231,7 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19285123125124152");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19285123125124152"));
@@ -227,8 +247,7 @@ namespace TSafeUnorderedMap {
       SafeUnorderedMap<Address, uint256_t> safeUnorderedMap;
       auto randomAddress = Address(Utils::randBytes(20));
       safeUnorderedMap[randomAddress] = uint256_t("19283815712031512");
-      /// Size should NOT count temporary variables
-      REQUIRE(safeUnorderedMap.size() == 0);
+      REQUIRE(safeUnorderedMap.size() == 1);
       auto found = safeUnorderedMap.find(randomAddress);
       REQUIRE(found != safeUnorderedMap.end());
       REQUIRE(found->second == uint256_t("19283815712031512"));


### PR DESCRIPTION
- Implement operator=()
- Implement size()
- Fix erase-insert-commit bug in commit()
- Improve & fix operator=() testcase that was calling the copy constructor instead
- Add erase-insert-commit regression test
- Fix all testcase asserts that depended on the placeholder size() code